### PR TITLE
fix: don't block crawl on cross-host robots.txt checks

### DIFF
--- a/lib/crawler/engine.ts
+++ b/lib/crawler/engine.ts
@@ -647,8 +647,12 @@ async function executeCrawl(
       if (!normalized || visited.has(normalized)) continue;
       if (!sameHost(normalized, seedUrl)) continue;
 
-      // Check robots.txt
-      if (robotsChecker && !robotsChecker.isAllowed(normalized, USER_AGENT)) {
+      // Check robots.txt. isAllowed() returns `undefined` (not `false`) when
+      // the URL's host differs from the one robots.txt was fetched from —
+      // e.g. an apex domain that redirects to www. sameHost() above already
+      // confirms it's the same site, so only an explicit `false` (a real
+      // Disallow match) should block the crawl here.
+      if (robotsChecker && robotsChecker.isAllowed(normalized, USER_AGENT) === false) {
         visited.add(normalized);
         continue;
       }


### PR DESCRIPTION
robots-parser's isAllowed() returned undefined (not false) when it differed from robots.txt. I had my url without the www. Because of the redirect every crawl beyond the single page was disallowed.  

sameHost() already confirms same-site before this check runs, so only an explicit false should block crawling here.