### PR TITLE
fix: duplicate crawl pages, hidden GSC errors, token-expiry units

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -41,7 +41,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               googleTokens: {
                 accessToken: account.access_token,
                 refreshToken: account.refresh_token,
-                expiresAt: account.expires_at,
+                // account.expires_at is Unix seconds; store ms to match
+                // refreshAccessToken() and getAccessToken()'s Date.now() checks.
+                expiresAt: account.expires_at
+                  ? account.expires_at * 1000
+                  : undefined,
                 tokenType: account.token_type,
                 scope: account.scope,
               },

--- a/lib/crawler/engine.ts
+++ b/lib/crawler/engine.ts
@@ -699,6 +699,15 @@ async function executeCrawl(
       const redirectUrl =
         finalNormalized !== url ? finalNormalized : null;
 
+      // A redirect can resolve to a URL that's also seeded from the sitemap or
+      // linked elsewhere. Only the requested URL was marked visited, so without
+      // this the resolved page gets fetched and stored twice — inflating page
+      // counts and producing phantom DUPLICATE_TITLE/DESCRIPTION issues.
+      if (redirectUrl) {
+        if (visited.has(finalNormalized)) continue;
+        visited.add(finalNormalized);
+      }
+
       const page = parseHtml(
         finalNormalized,
         res.html,

--- a/lib/google/gsc-client.ts
+++ b/lib/google/gsc-client.ts
@@ -63,7 +63,12 @@ async function refreshAccessToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to refresh token: ${response.statusText}`);
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Failed to refresh token: ${response.status} ${response.statusText}${
+        body ? ` — ${body.slice(0, 500)}` : ""
+      }`
+    );
   }
 
   const data = (await response.json()) as {
@@ -135,8 +140,11 @@ export async function listGSCProperties(
   });
 
   if (!response.ok) {
+    const body = await response.text().catch(() => "");
     throw new Error(
-      `Failed to list GSC properties: ${response.statusText}`
+      `Failed to list GSC properties: ${response.status} ${response.statusText}${
+        body ? ` — ${body.slice(0, 500)}` : ""
+      }`
     );
   }
 


### PR DESCRIPTION
Closes #4.

Three independent data-accuracy bugs in the crawl/GSC pipeline, one commit each.

## Changes

**`fix(crawler)` — dedupe redirected pages** (`lib/crawler/engine.ts`)
`page.url` is the post-redirect URL, but only the *requested* URL was added to `visited`. A redirect target also present in the sitemap or internal links (e.g. `/` → `/en`) was fetched and persisted twice. Now the resolved URL is marked visited and skipped if already seen.
_Fixes inflated page counts and the phantom `DUPLICATE_TITLE`/`DUPLICATE_DESCRIPTION` issues (the detector was comparing two identical rows of the same page)._

**`fix(gsc)` — surface API error body** (`lib/google/gsc-client.ts`)
`listGSCProperties` and `refreshAccessToken` threw only `response.statusText`. Now they include the status code and the response body (truncated to 500 chars), so a 403 shows `insufficient scopes` / `SERVICE_DISABLED` instead of a bare `Forbidden`.

**`fix(auth)` — token expiry in ms** (`lib/auth.ts`)
`account.expires_at` (Unix seconds) was stored as-is, but `getAccessToken` compares against `Date.now()` (ms) and `refreshAccessToken` stores ms. The mismatch refreshed the token on every call. Converted to ms on store.

## Verification
- Root cause of the duplicate rows traced to `AuditPage` holding two identical rows per redirected URL on a live crawl (`/en`, `/en/privacy`, `/en/terms` doubled — all sitemap-seeded; `/en/contact` single — not seeded).
- `npx tsc --noEmit` clean (0 errors).
- No test suite in the repo; changes are minimal and localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)