### PR TITLE
feat: clickable keyword/page detail pages + GBP progress report & scheduled sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,10 @@ NEXTAUTH_SECRET=generate-with-openssl-rand-hex-32
 # AUTH_SECRET works as alias for Auth.js v5
 # AUTH_SECRET=
 
-# ============ OPTIONAL: Scheduling ============
+# ============ SCHEDULING ============
+# Required for the Vercel Cron GSC sync (vercel.json → /api/cron/gsc-sync,
+# runs every 6 hours). Vercel sends this as a Bearer token to authorize the job.
+CRON_SECRET=generate-with-openssl-rand-hex-32
 # Cron format: "minute hour day-of-month month day-of-week"
 # CRAWL_SCHEDULE=0 0 * * 0                    # Weekly Sunday midnight
 # GSC_SYNC_SCHEDULE=0 2 * * *                 # Daily 2am UTC

--- a/app/(dashboard)/sites/[siteId]/gbp-progress/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/gbp-progress/page.tsx
@@ -1,0 +1,31 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { redirect } from "next/navigation";
+import { PageHeader } from "@/components/ui/page-header";
+import { GBPProgressClient } from "@/components/research/gbp-progress-client";
+
+interface Props {
+  params: Promise<{ siteId: string }>;
+}
+
+export default async function GBPProgressPage({ params }: Props) {
+  const session = await auth();
+  const { siteId } = await params;
+
+  const site = await db.site.findUnique({
+    where: { id: siteId },
+    select: { userId: true, domain: true },
+  });
+  if (!site || site.userId !== session?.user?.id) redirect("/sites");
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow={site.domain}
+        title="GBP Progress Report"
+        description="Google Business Profile views, searches, and customer actions over time"
+      />
+      <GBPProgressClient siteId={siteId} />
+    </div>
+  );
+}

--- a/app/(dashboard)/sites/[siteId]/keywords/detail/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/keywords/detail/page.tsx
@@ -1,0 +1,205 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { PageHeader } from "@/components/ui/page-header";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PositionBadge } from "@/components/ui/data-table";
+import {
+  RankHistoryChart,
+  type RankHistoryPoint,
+} from "@/components/research/rank-history-chart";
+import { KeywordSavePanel } from "@/components/research/keyword-save-panel";
+import { formatCompact, formatCtr } from "@/lib/seo-metrics";
+import { getDateRange } from "@/lib/date-utils";
+
+interface Props {
+  params: Promise<{ siteId: string }>;
+  searchParams: Promise<{ query?: string }>;
+}
+
+export default async function KeywordDetailPage({ params, searchParams }: Props) {
+  const session = await auth();
+  const { siteId } = await params;
+  const { query } = await searchParams;
+
+  const site = await db.site.findUnique({
+    where: { id: siteId },
+    select: { userId: true, domain: true },
+  });
+  if (!site || site.userId !== session?.user?.id) redirect("/sites");
+  if (!query) notFound();
+
+  // 28-day aggregate for the summary + a 90-day series for the chart.
+  const { start, end } = getDateRange(28);
+  const summaryStart = new Date(`${start}T00:00:00.000Z`);
+  const summaryEnd = new Date(`${end}T23:59:59.999Z`);
+  const historyStart = new Date();
+  historyStart.setUTCDate(historyStart.getUTCDate() - 90);
+  historyStart.setUTCHours(0, 0, 0, 0);
+
+  const [summaryRows, historyRows, saved] = await Promise.all([
+    db.keyword.findMany({
+      where: { siteId, query, date: { gte: summaryStart, lte: summaryEnd } },
+      select: { clicks: true, impressions: true, position: true, page: true },
+    }),
+    db.keyword.findMany({
+      where: { siteId, query, date: { gte: historyStart } },
+      select: { date: true, clicks: true, impressions: true, position: true },
+      orderBy: { date: "asc" },
+    }),
+    db.savedKeyword.findUnique({
+      where: { siteId_query: { siteId, query } },
+      select: { tags: true, notes: true },
+    }),
+  ]);
+
+  const clicks = summaryRows.reduce((s, r) => s + r.clicks, 0);
+  const impressions = summaryRows.reduce((s, r) => s + r.impressions, 0);
+  const weightedPos =
+    summaryRows.reduce((s, r) => s + r.position * Math.max(r.impressions, 1), 0) /
+    Math.max(
+      summaryRows.reduce((s, r) => s + Math.max(r.impressions, 1), 0),
+      1
+    );
+  const ctr = impressions > 0 ? clicks / impressions : 0;
+
+  // Top landing page for this query over the window.
+  const pageClicks = new Map<string, number>();
+  for (const r of summaryRows) {
+    if (!r.page) continue;
+    pageClicks.set(r.page, (pageClicks.get(r.page) ?? 0) + r.clicks);
+  }
+  const topPage = [...pageClicks.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+
+  // Aggregate history rows by date (impression-weighted position).
+  const byDate = new Map<string, RankHistoryPoint>();
+  for (const r of historyRows) {
+    const date = r.date.toISOString().slice(0, 10);
+    const existing = byDate.get(date);
+    if (existing) {
+      const totalImpr = existing.impressions + r.impressions;
+      existing.position =
+        totalImpr > 0
+          ? (existing.position * existing.impressions + r.position * r.impressions) /
+            totalImpr
+          : (existing.position + r.position) / 2;
+      existing.clicks += r.clicks;
+      existing.impressions += r.impressions;
+    } else {
+      byDate.set(date, {
+        date,
+        position: r.position,
+        clicks: r.clicks,
+        impressions: r.impressions,
+      });
+    }
+  }
+  const history = [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+
+  const hasData = summaryRows.length > 0 || history.length > 0;
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow={site.domain}
+        title={query}
+        description="Keyword performance and rank history over the last 90 days."
+        actions={
+          <Link
+            href={`/sites/${siteId}/keywords`}
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+          >
+            <ArrowLeft className="size-3.5" />
+            Back to keywords
+          </Link>
+        }
+      />
+
+      {!hasData ? (
+        <EmptyState
+          icon="⌘"
+          title="No data for this keyword"
+          description="This query has no Search Console rows in the selected window."
+        />
+      ) : (
+        <div className="grid gap-5 lg:grid-cols-3">
+          <div className="space-y-5 lg:col-span-2">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatCard label="Position">
+                <PositionBadge position={weightedPos} />
+              </StatCard>
+              <StatCard label="Clicks" value={formatCompact(clicks)} />
+              <StatCard label="Impressions" value={formatCompact(impressions)} />
+              <StatCard label="CTR" value={formatCtr(ctr)} />
+            </div>
+
+            <RankHistoryChart data={history} />
+
+            {topPage && (
+              <div className="panel p-5">
+                <p className="mb-1 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                  Top landing page
+                </p>
+                <a
+                  href={topPage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="break-all text-sm font-medium text-signal hover:underline"
+                >
+                  {topPage}
+                </a>
+                <div className="mt-2">
+                  <Link
+                    href={`/sites/${siteId}/pages/detail?url=${encodeURIComponent(topPage)}`}
+                    className="text-xs font-medium text-primary hover:underline"
+                  >
+                    View page details →
+                  </Link>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="lg:col-span-1">
+            <KeywordSavePanel
+              siteId={siteId}
+              query={query}
+              initialSaved={saved !== null}
+              initialTags={saved?.tags ?? []}
+              initialNotes={saved?.notes ?? ""}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  children,
+}: {
+  label: string;
+  value?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="panel p-4">
+      <p className="mb-1.5 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </p>
+      {children ?? (
+        <p className="font-data text-atom-subheader font-semibold text-foreground">
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const metadata = {
+  title: "Keyword detail",
+};

--- a/app/(dashboard)/sites/[siteId]/keywords/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/keywords/page.tsx
@@ -51,7 +51,7 @@ export default async function KeywordsPage({ params }: KeywordsPageProps) {
           description="Sync Google Search Console to populate query-level performance."
         />
       ) : (
-        <KeywordsTable keywords={keywords} />
+        <KeywordsTable keywords={keywords} siteId={siteId} />
       )}
     </div>
   );

--- a/app/(dashboard)/sites/[siteId]/pages/detail/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/pages/detail/page.tsx
@@ -1,0 +1,236 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+import { PageHeader } from "@/components/ui/page-header";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  MetricTable,
+  PositionBadge,
+  NumCell,
+  CtrCell,
+} from "@/components/ui/data-table";
+import {
+  AreaMetricChart,
+  type AreaMetricPoint,
+} from "@/components/research/area-metric-chart";
+import { formatCompact, formatCtr } from "@/lib/seo-metrics";
+import { getDateRange } from "@/lib/date-utils";
+
+interface Props {
+  params: Promise<{ siteId: string }>;
+  searchParams: Promise<{ url?: string }>;
+}
+
+export default async function PageDetailPage({ params, searchParams }: Props) {
+  const session = await auth();
+  const { siteId } = await params;
+  const { url } = await searchParams;
+
+  const site = await db.site.findUnique({
+    where: { id: siteId },
+    select: { userId: true, domain: true },
+  });
+  if (!site || site.userId !== session?.user?.id) redirect("/sites");
+  if (!url) notFound();
+
+  const { start, end } = getDateRange(28);
+  const summaryStart = new Date(`${start}T00:00:00.000Z`);
+  const summaryEnd = new Date(`${end}T23:59:59.999Z`);
+  const historyStart = new Date();
+  historyStart.setUTCDate(historyStart.getUTCDate() - 90);
+  historyStart.setUTCHours(0, 0, 0, 0);
+
+  const [summaryRows, historyRows, queryRows] = await Promise.all([
+    db.page.findMany({
+      where: { siteId, url, date: { gte: summaryStart, lte: summaryEnd } },
+      select: { clicks: true, impressions: true, position: true },
+    }),
+    db.page.findMany({
+      where: { siteId, url, date: { gte: historyStart } },
+      select: { date: true, clicks: true, impressions: true },
+      orderBy: { date: "asc" },
+    }),
+    db.keyword.findMany({
+      where: { siteId, page: url, date: { gte: summaryStart, lte: summaryEnd } },
+      select: { query: true, clicks: true, impressions: true, position: true },
+    }),
+  ]);
+
+  const clicks = summaryRows.reduce((s, r) => s + r.clicks, 0);
+  const impressions = summaryRows.reduce((s, r) => s + r.impressions, 0);
+  const weightedPos =
+    summaryRows.reduce((s, r) => s + r.position * Math.max(r.impressions, 1), 0) /
+    Math.max(
+      summaryRows.reduce((s, r) => s + Math.max(r.impressions, 1), 0),
+      1
+    );
+  const ctr = impressions > 0 ? clicks / impressions : 0;
+
+  // Aggregate 90-day history by date.
+  const byDate = new Map<string, AreaMetricPoint>();
+  for (const r of historyRows) {
+    const date = r.date.toISOString().slice(0, 10);
+    const existing = byDate.get(date);
+    if (existing) {
+      existing.clicks += r.clicks;
+      existing.impressions += r.impressions;
+    } else {
+      byDate.set(date, { date, clicks: r.clicks, impressions: r.impressions });
+    }
+  }
+  const history = [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+
+  // Top queries driving this page.
+  const byQuery = new Map<
+    string,
+    { clicks: number; impressions: number; weightedPos: number }
+  >();
+  for (const r of queryRows) {
+    const existing = byQuery.get(r.query) ?? {
+      clicks: 0,
+      impressions: 0,
+      weightedPos: 0,
+    };
+    existing.clicks += r.clicks;
+    existing.impressions += r.impressions;
+    existing.weightedPos += r.position * Math.max(r.impressions, 1);
+    byQuery.set(r.query, existing);
+  }
+  const topQueries = [...byQuery.entries()]
+    .map(([query, d]) => {
+      const weight = Math.max(d.impressions, 1);
+      return {
+        query,
+        clicks: d.clicks,
+        impressions: d.impressions,
+        position: d.weightedPos / weight,
+        ctr: d.impressions > 0 ? d.clicks / d.impressions : 0,
+      };
+    })
+    .sort((a, b) => b.clicks - a.clicks || b.impressions - a.impressions)
+    .slice(0, 25);
+
+  const href = url.startsWith("http")
+    ? url
+    : `https://${site.domain}${url.startsWith("/") ? "" : "/"}${url}`;
+
+  const hasData = summaryRows.length > 0 || history.length > 0;
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow={site.domain}
+        title={url}
+        description="Landing page performance and top queries over the last 90 days."
+        actions={
+          <div className="flex flex-wrap items-center gap-3">
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-signal transition hover:underline"
+            >
+              <ExternalLink className="size-3.5" />
+              Open page
+            </a>
+            <Link
+              href={`/sites/${siteId}/pages`}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+            >
+              <ArrowLeft className="size-3.5" />
+              Back to pages
+            </Link>
+          </div>
+        }
+      />
+
+      {!hasData ? (
+        <EmptyState
+          icon="◫"
+          title="No data for this page"
+          description="This URL has no Search Console rows in the selected window."
+        />
+      ) : (
+        <div className="space-y-5">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <StatCard label="Position">
+              <PositionBadge position={weightedPos} />
+            </StatCard>
+            <StatCard label="Clicks" value={formatCompact(clicks)} />
+            <StatCard label="Impressions" value={formatCompact(impressions)} />
+            <StatCard label="CTR" value={formatCtr(ctr)} />
+          </div>
+
+          <AreaMetricChart data={history} title="Page traffic" />
+
+          {topQueries.length > 0 && (
+            <MetricTable
+              headers={[
+                { label: "Query" },
+                { label: "Position", align: "right" },
+                { label: "Clicks", align: "right" },
+                { label: "Impressions", align: "right" },
+                { label: "CTR", align: "right" },
+              ]}
+              footer={`Top ${topQueries.length} queries for this page · last 28 days`}
+            >
+              {topQueries.map((kw) => (
+                <tr key={kw.query} className="transition-colors hover:bg-muted/25">
+                  <td className="max-w-md px-4 py-3">
+                    <Link
+                      href={`/sites/${siteId}/keywords/detail?query=${encodeURIComponent(kw.query)}`}
+                      className="font-medium text-foreground hover:text-primary hover:underline"
+                    >
+                      {kw.query}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <PositionBadge position={kw.position} />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <NumCell value={kw.clicks} />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <NumCell value={kw.impressions} />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <CtrCell ctr={kw.ctr} />
+                  </td>
+                </tr>
+              ))}
+            </MetricTable>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  children,
+}: {
+  label: string;
+  value?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="panel p-4">
+      <p className="mb-1.5 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </p>
+      {children ?? (
+        <p className="font-data text-atom-subheader font-semibold text-foreground">
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const metadata = {
+  title: "Page detail",
+};

--- a/app/(dashboard)/sites/[siteId]/pages/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/pages/page.tsx
@@ -1,6 +1,8 @@
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import Link from "next/link";
 import { redirect } from "next/navigation";
+import { ExternalLink } from "lucide-react";
 import { getTopPages } from "@/lib/seo-metrics";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -76,14 +78,23 @@ export default async function PagesPage({ params }: PagesPageProps) {
                 className="transition-colors hover:bg-muted/25"
               >
                 <td className="max-w-xl px-4 py-3">
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="break-all font-medium text-signal hover:underline"
-                  >
-                    {page.url}
-                  </a>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      href={`/sites/${siteId}/pages/detail?url=${encodeURIComponent(page.url)}`}
+                      className="break-all font-medium text-foreground transition hover:text-primary hover:underline"
+                    >
+                      {page.url}
+                    </Link>
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 text-muted-foreground transition hover:text-signal"
+                      title="Open page in new tab"
+                    >
+                      <ExternalLink className="size-3.5" />
+                    </a>
+                  </div>
                 </td>
                 <td className="px-4 py-3 text-right">
                   <PositionBadge position={page.position} />

--- a/app/(dashboard)/sites/[siteId]/saved-keywords/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/saved-keywords/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -78,6 +79,9 @@ export default async function SavedKeywordsPage({ params }: Props) {
                     Keyword
                   </th>
                   <th className="px-4 py-3 text-left text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                    Tags
+                  </th>
+                  <th className="px-4 py-3 text-left text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                     Notes
                   </th>
                   <th className="px-4 py-3 text-right text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
@@ -103,7 +107,28 @@ export default async function SavedKeywordsPage({ params }: Props) {
                   return (
                     <tr key={kw.id} className="transition-colors hover:bg-muted/25">
                       <td className="px-4 py-3 font-medium text-foreground">
-                        {kw.query}
+                        <Link
+                          href={`/sites/${siteId}/keywords/detail?query=${encodeURIComponent(kw.query)}`}
+                          className="transition hover:text-primary hover:underline"
+                        >
+                          {kw.query}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        {kw.tags.length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {kw.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center rounded-full bg-primary/12 px-2 py-0.5 text-[11px] font-medium text-primary"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
                       </td>
                       <td className="max-w-xs truncate px-4 py-3 text-muted-foreground">
                         {kw.notes || "—"}

--- a/app/api/cron/gsc-sync/route.ts
+++ b/app/api/cron/gsc-sync/route.ts
@@ -1,0 +1,62 @@
+import { db } from "@/lib/db";
+import { syncGSCDataForSite } from "@/lib/workers/gsc-sync";
+import { syncGBPDataForSite } from "@/lib/workers/gbp-sync";
+
+export const maxDuration = 300;
+
+/**
+ * Scheduled GSC + GBP sync. Invoked by Vercel Cron (see vercel.json) every 6
+ * hours. Refreshes the last 28 days of GSC keyword + page data for every site
+ * with a connected GSC property, and the rolling Business Profile daily metrics
+ * for every site with a linked GBP location.
+ *
+ * Protected by CRON_SECRET: Vercel automatically sends
+ * `Authorization: Bearer <CRON_SECRET>` when the env var is set.
+ */
+export async function GET(req: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return Response.json(
+      { error: "CRON_SECRET is not configured" },
+      { status: 500 }
+    );
+  }
+  if (req.headers.get("authorization") !== `Bearer ${secret}`) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const [gscSites, gbpSites] = await Promise.all([
+    db.site.findMany({
+      where: { gscProperty: { not: null } },
+      select: { id: true, userId: true },
+    }),
+    db.site.findMany({
+      where: { gbpLocation: { not: null } },
+      select: { id: true, userId: true },
+    }),
+  ]);
+
+  let gscSynced = 0;
+  let gscFailed = 0;
+  let gbpSynced = 0;
+  let gbpFailed = 0;
+
+  // Sequential to avoid hammering the Google APIs and token-refresh contention.
+  for (const site of gscSites) {
+    const result = await syncGSCDataForSite(site.userId, site.id);
+    if (result.success) gscSynced++;
+    else gscFailed++;
+  }
+
+  for (const site of gbpSites) {
+    const result = await syncGBPDataForSite(site.userId, site.id);
+    if (result.success) gbpSynced++;
+    else gbpFailed++;
+  }
+
+  return Response.json({
+    ok: true,
+    gsc: { total: gscSites.length, synced: gscSynced, failed: gscFailed },
+    gbp: { total: gbpSites.length, synced: gbpSynced, failed: gbpFailed },
+  });
+}

--- a/app/api/sites/[siteId]/gbp/locations/route.ts
+++ b/app/api/sites/[siteId]/gbp/locations/route.ts
@@ -1,0 +1,82 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { listGBPLocations } from "@/lib/google/gbp-client";
+
+async function requireOwnedSite(siteId: string, userId: string) {
+  const site = await db.site.findUnique({
+    where: { id: siteId },
+    select: { userId: true },
+  });
+  return site && site.userId === userId ? site : null;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ siteId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { siteId } = await params;
+    const site = await requireOwnedSite(siteId, session.user.id);
+    if (!site) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const locations = await listGBPLocations(session.user.id);
+    return Response.json({ locations });
+  } catch (error) {
+    console.error("GBP locations error:", error);
+    return Response.json(
+      { error: "Failed to list Business Profile locations" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ siteId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { siteId } = await params;
+    const site = await requireOwnedSite(siteId, session.user.id);
+    if (!site) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = (await req.json().catch(() => null)) as {
+      location?: unknown;
+      label?: unknown;
+    } | null;
+
+    const location = typeof body?.location === "string" ? body.location : null;
+    const label = typeof body?.label === "string" ? body.label : null;
+
+    // Accept the resource name form "locations/12345", or clear the link with null.
+    if (location !== null && !/^locations\/\d+$/.test(location)) {
+      return Response.json({ error: "Invalid location" }, { status: 400 });
+    }
+
+    await db.site.update({
+      where: { id: siteId },
+      data: { gbpLocation: location, gbpLabel: location ? label : null },
+    });
+
+    return Response.json({ ok: true });
+  } catch (error) {
+    console.error("GBP location update error:", error);
+    return Response.json(
+      { error: "Failed to update Business Profile location" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/sites/[siteId]/gbp/route.ts
+++ b/app/api/sites/[siteId]/gbp/route.ts
@@ -1,0 +1,118 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import {
+  buildGBPReport,
+  fetchGBPSupplemental,
+  gbpLatestDataDate,
+  type GBPRawDaily,
+} from "@/lib/google/gbp-client";
+import { syncGBPDataForSite } from "@/lib/workers/gbp-sync";
+
+const ALLOWED_DAYS = [28, 90, 180, 365];
+
+function toDateKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Maps a stored GBPDailyMetric row to the raw shape the report builder expects. */
+function rowToRaw(row: {
+  date: Date;
+  desktopMaps: number;
+  desktopSearch: number;
+  mobileMaps: number;
+  mobileSearch: number;
+  websiteClicks: number;
+  callClicks: number;
+  directionRequests: number;
+  conversations: number;
+  bookings: number;
+}): GBPRawDaily {
+  return {
+    date: toDateKey(row.date),
+    desktopMaps: row.desktopMaps,
+    desktopSearch: row.desktopSearch,
+    mobileMaps: row.mobileMaps,
+    mobileSearch: row.mobileSearch,
+    websiteClicks: row.websiteClicks,
+    callClicks: row.callClicks,
+    directionRequests: row.directionRequests,
+    conversations: row.conversations,
+    bookings: row.bookings,
+  };
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ siteId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { siteId } = await params;
+    const site = await db.site.findUnique({
+      where: { id: siteId },
+      select: { userId: true, gbpLocation: true, gbpLabel: true },
+    });
+    if (!site || site.userId !== session.user.id) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+
+    if (!site.gbpLocation) {
+      return Response.json({ needsSetup: true });
+    }
+
+    const daysParam = Number(new URL(req.url).searchParams.get("days"));
+    const days = ALLOWED_DAYS.includes(daysParam) ? daysParam : 90;
+
+    // Reporting window and the immediately-prior window used for deltas.
+    const end = gbpLatestDataDate();
+    const start = new Date(end);
+    start.setUTCDate(start.getUTCDate() - (days - 1));
+    const prevStart = new Date(start);
+    prevStart.setUTCDate(prevStart.getUTCDate() - days);
+
+    // Backfill on first load if we have no stored data for this site yet.
+    const existing = await db.gBPDailyMetric.count({ where: { siteId } });
+    if (existing === 0) {
+      await syncGBPDataForSite(session.user.id, siteId);
+    }
+
+    const stored = await db.gBPDailyMetric.findMany({
+      where: { siteId, date: { gte: prevStart, lte: end } },
+      orderBy: { date: "asc" },
+    });
+
+    const rows = stored.map(rowToRaw);
+    const startKey = toDateKey(start);
+    const currentRows = rows.filter((r) => r.date >= startKey);
+    const previousRows = rows.filter((r) => r.date < startKey);
+
+    const supplemental = await fetchGBPSupplemental(
+      session.user.id,
+      site.gbpLocation,
+      start,
+      end
+    ).catch(() => ({ searchKeywords: [], reviews: null }));
+
+    const report = buildGBPReport({
+      location: site.gbpLocation,
+      days,
+      startDate: startKey,
+      endDate: toDateKey(end),
+      currentRows,
+      previousRows,
+      supplemental,
+    });
+
+    return Response.json({ ...report, label: site.gbpLabel });
+  } catch (error) {
+    console.error("GBP report error:", error);
+    return Response.json(
+      { error: "Failed to load Business Profile metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/sites/[siteId]/saved-keywords/route.ts
+++ b/app/api/sites/[siteId]/saved-keywords/route.ts
@@ -80,13 +80,29 @@ export async function POST(
       return Response.json({ error: "Not found" }, { status: 404 });
     }
 
-    const body = (await req.json()) as { query?: string; notes?: string };
+    const body = (await req.json()) as {
+      query?: string;
+      notes?: string;
+      tags?: unknown;
+    };
     if (!body.query || typeof body.query !== "string") {
       return Response.json(
         { error: "Missing required field: query" },
         { status: 400 }
       );
     }
+
+    // Normalize tags: strings only, trimmed, de-duplicated, capped.
+    const tags = Array.isArray(body.tags)
+      ? Array.from(
+          new Set(
+            body.tags
+              .filter((t): t is string => typeof t === "string")
+              .map((t) => t.trim())
+              .filter((t) => t.length > 0 && t.length <= 40)
+          )
+        ).slice(0, 20)
+      : undefined;
 
     const saved = await db.savedKeyword.upsert({
       where: {
@@ -99,9 +115,11 @@ export async function POST(
         siteId,
         query: body.query,
         notes: body.notes ?? null,
+        tags: tags ?? [],
       },
       update: {
         notes: body.notes ?? undefined,
+        tags: tags ?? undefined,
       },
     });
 

--- a/components/dashboard/top-keywords.tsx
+++ b/components/dashboard/top-keywords.tsx
@@ -75,9 +75,12 @@ export async function TopKeywords({
                       <span className="font-data w-5 text-xs text-muted-foreground">
                         {idx + 1}
                       </span>
-                      <span className="font-medium text-foreground">
+                      <Link
+                        href={`/sites/${siteId}/keywords/detail?query=${encodeURIComponent(keyword.query)}`}
+                        className="font-medium text-primary underline decoration-primary/40 underline-offset-2 transition hover:decoration-primary"
+                      >
                         {keyword.query}
-                      </span>
+                      </Link>
                     </div>
                   </td>
                   <td className="px-4 py-3 text-right">

--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -17,6 +17,7 @@ import {
   Bot,
   Link as LinkIcon,
   SearchCheck,
+  MapPin,
   type LucideIcon,
 } from "lucide-react";
 
@@ -62,6 +63,7 @@ export function SidebarNav({
           { href: `/sites/${activeSiteId}/pages`, label: "Pages", icon: FileText },
           { href: `/sites/${activeSiteId}/crawl`, label: "Crawl / Audit", icon: Bug },
           { href: `/sites/${activeSiteId}/vitals`, label: "Vitals", icon: Gauge },
+          { href: `/sites/${activeSiteId}/gbp-progress`, label: "GBP Progress", icon: MapPin },
           { href: `/sites/${activeSiteId}/opportunities`, label: "Opportunities", icon: Lightbulb },
           { href: `/sites/${activeSiteId}/alerts`, label: "Alerts", icon: Bell },
         ],

--- a/components/research/area-metric-chart.tsx
+++ b/components/research/area-metric-chart.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export interface AreaMetricPoint {
+  date: string; // YYYY-MM-DD
+  clicks: number;
+  impressions: number;
+}
+
+function formatAxisDate(value: string) {
+  const d = new Date(`${value}T00:00:00Z`);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+const PRIMARY = "#A78BFA";
+const SIGNAL = "#34D399";
+const AXIS = "#71717A";
+const GRID = "rgba(255,255,255,0.06)";
+
+export function AreaMetricChart({
+  data,
+  title = "Search traffic",
+}: {
+  data: AreaMetricPoint[];
+  title?: string;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="panel flex h-72 flex-col items-center justify-center gap-2">
+        <p className="font-heading text-atom-subheader font-medium text-foreground">
+          No traffic yet
+        </p>
+        <p className="text-atom-body text-muted-foreground">
+          Sync GSC data to populate this chart.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel p-5 sm:p-6">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+            {title}
+          </h3>
+          <p className="text-atom-caption text-muted-foreground">
+            Daily clicks &amp; impressions · last {data.length} days
+          </p>
+        </div>
+        <div className="flex gap-4 text-atom-caption">
+          <span className="inline-flex items-center gap-2 text-muted-foreground">
+            <span className="size-2 rounded-full" style={{ background: PRIMARY }} /> Clicks
+          </span>
+          <span className="inline-flex items-center gap-2 text-muted-foreground">
+            <span className="size-2 rounded-full" style={{ background: SIGNAL }} /> Impressions
+          </span>
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id="pgClicksFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={PRIMARY} stopOpacity={0.28} />
+              <stop offset="100%" stopColor={PRIMARY} stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="pgImprFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={SIGNAL} stopOpacity={0.18} />
+              <stop offset="100%" stopColor={SIGNAL} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke={GRID} strokeDasharray="4 6" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatAxisDate}
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            minTickGap={28}
+          />
+          <YAxis
+            yAxisId="clicks"
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={40}
+          />
+          <YAxis
+            yAxisId="impressions"
+            orientation="right"
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={48}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "#161618",
+              border: "1px solid rgba(255,255,255,0.08)",
+              borderRadius: 14,
+              fontSize: 12,
+              boxShadow: "0 16px 40px rgba(0,0,0,0.55)",
+              color: "#F4F4F5",
+            }}
+            labelFormatter={(label) => formatAxisDate(String(label))}
+            formatter={(value, name) => [
+              typeof value === "number" ? value.toLocaleString() : value,
+              name === "clicks" ? "Clicks" : "Impressions",
+            ]}
+          />
+          <Area
+            yAxisId="impressions"
+            type="monotone"
+            dataKey="impressions"
+            stroke={SIGNAL}
+            fill="url(#pgImprFill)"
+            strokeWidth={2}
+            isAnimationActive={false}
+          />
+          <Area
+            yAxisId="clicks"
+            type="monotone"
+            dataKey="clicks"
+            stroke={PRIMARY}
+            fill="url(#pgClicksFill)"
+            strokeWidth={2}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/components/research/gbp-progress-client.tsx
+++ b/components/research/gbp-progress-client.tsx
@@ -1,0 +1,802 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  Eye,
+  Search,
+  MousePointerClick,
+  Navigation,
+  Phone,
+  Sparkles,
+  Star,
+  Loader2,
+  MapPin,
+  AlertTriangle,
+  Check,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types (mirror lib/google/gbp-client.ts)
+// ---------------------------------------------------------------------------
+
+interface Totals {
+  views: number;
+  searches: number;
+  websiteClicks: number;
+  directions: number;
+  calls: number;
+  interactions: number;
+}
+
+interface DailyPoint extends Totals {
+  date: string;
+}
+
+interface MonthlyRow extends Totals {
+  month: string;
+  label: string;
+}
+
+interface Slice {
+  label: string;
+  value: number;
+}
+
+interface SearchKeyword {
+  keyword: string;
+  impressions: number;
+  approximate: boolean;
+}
+
+interface Reviews {
+  averageRating: number;
+  totalReviews: number;
+  distribution: Record<string, number>;
+}
+
+interface Report {
+  label?: string | null;
+  periodDays: number;
+  startDate: string;
+  endDate: string;
+  totals: Totals;
+  deltas: Totals;
+  daily: DailyPoint[];
+  monthly: MonthlyRow[];
+  findYou: Slice[];
+  actions: Slice[];
+  searchKeywords: SearchKeyword[];
+  reviews: Reviews | null;
+}
+
+interface LocationOption {
+  name: string;
+  title: string;
+  address: string | null;
+  phone: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting + palette
+// ---------------------------------------------------------------------------
+
+function fmtCompact(num: number): string {
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
+  if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+  return num.toLocaleString();
+}
+
+/** delta arrives on a 0-1 scale (0.638 => +63.8%). */
+function fmtDelta(v: number): string {
+  const pct = v * 100;
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+const PALETTE = ["#A78BFA", "#34D399", "#38BDF8", "#FBBF24", "#F472B6", "#F87171"];
+const AXIS = "#71717A";
+const GRID = "rgba(255,255,255,0.06)";
+
+const TOOLTIP_STYLE = {
+  background: "#161618",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 14,
+  fontSize: 12,
+  boxShadow: "0 16px 40px rgba(0,0,0,0.55)",
+  color: "#F4F4F5",
+} as const;
+
+const DAY_OPTIONS = [
+  { value: 28, label: "28 days" },
+  { value: 90, label: "90 days" },
+  { value: 180, label: "6 months" },
+  { value: 365, label: "12 months" },
+];
+
+function formatAxisDate(value: string) {
+  const d = new Date(`${value}T00:00:00Z`);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// ---------------------------------------------------------------------------
+// Metric card
+// ---------------------------------------------------------------------------
+
+function MetricCard({
+  label,
+  value,
+  delta,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  delta: number;
+  icon: React.ComponentType<{ className?: string }>;
+}) {
+  const isFlat = !Number.isFinite(delta) || Math.abs(delta) < 0.0005;
+  const good = delta > 0;
+
+  return (
+    <div className="panel relative p-4 sm:p-5">
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Icon className="size-4 text-primary" />
+        <p className="text-atom-caption font-semibold uppercase tracking-[0.1em]">
+          {label}
+        </p>
+      </div>
+      <p className="mt-3 font-heading text-atom-display1 font-semibold tracking-tight text-foreground">
+        {value}
+      </p>
+      <div
+        className={cn(
+          "mt-2 inline-flex items-center gap-1 rounded-md px-2 py-1 font-data text-xs font-semibold",
+          isFlat && "bg-muted text-muted-foreground",
+          !isFlat && good && "bg-signal-muted text-signal",
+          !isFlat && !good && "bg-[var(--a-danger-300)] text-[var(--a-danger-900)]"
+        )}
+      >
+        {isFlat ? "—" : fmtDelta(delta)}
+      </div>
+      <span className="ml-2 text-atom-caption text-muted-foreground">
+        vs prior period
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function GBPProgressClient({ siteId }: { siteId: string }) {
+  const [days, setDays] = useState(90);
+  const [report, setReport] = useState<Report | null>(null);
+  const [needsSetup, setNeedsSetup] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/gbp?days=${days}`);
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load report");
+      if (json.needsSetup) {
+        setNeedsSetup(true);
+        setReport(null);
+      } else {
+        setNeedsSetup(false);
+        setReport(json as Report);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load report");
+    } finally {
+      setLoading(false);
+    }
+  }, [siteId, days]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="panel flex h-72 items-center justify-center gap-2 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        <span className="text-atom-body">Loading Business Profile metrics…</span>
+      </div>
+    );
+  }
+
+  if (needsSetup) {
+    return <SetupPanel siteId={siteId} onLinked={load} />;
+  }
+
+  if (error) {
+    return (
+      <div className="panel flex flex-col items-center justify-center gap-2 py-12 text-center">
+        <AlertTriangle className="size-6 text-danger" />
+        <p className="text-atom-body text-foreground">{error}</p>
+        <button
+          type="button"
+          onClick={load}
+          className="mt-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!report) return null;
+
+  return (
+    <div className="space-y-6">
+      {/* Period selector + linked location */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-atom-caption text-muted-foreground">
+          <MapPin className="size-4 text-primary" />
+          <span className="text-foreground">{report.label ?? "Linked location"}</span>
+          <span>·</span>
+          <span>
+            {report.startDate} → {report.endDate}
+          </span>
+        </div>
+        <div className="flex gap-1 rounded-xl border border-border bg-card p-1">
+          {DAY_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setDays(opt.value)}
+              className={cn(
+                "rounded-lg px-3 py-1.5 text-xs font-medium transition",
+                days === opt.value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Metric cards */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
+        <MetricCard label="Total views" value={fmtCompact(report.totals.views)} delta={report.deltas.views} icon={Eye} />
+        <MetricCard label="Searches" value={fmtCompact(report.totals.searches)} delta={report.deltas.searches} icon={Search} />
+        <MetricCard label="Website clicks" value={fmtCompact(report.totals.websiteClicks)} delta={report.deltas.websiteClicks} icon={MousePointerClick} />
+        <MetricCard label="Directions" value={fmtCompact(report.totals.directions)} delta={report.deltas.directions} icon={Navigation} />
+        <MetricCard label="Phone calls" value={fmtCompact(report.totals.calls)} delta={report.deltas.calls} icon={Phone} />
+        <MetricCard label="Interactions" value={fmtCompact(report.totals.interactions)} delta={report.deltas.interactions} icon={Sparkles} />
+      </div>
+
+      {/* Time series */}
+      <div className="grid gap-4 xl:grid-cols-2">
+        <TrendChart
+          title="Performance over time"
+          subtitle="Views, searches & website clicks"
+          data={report.daily}
+          series={[
+            { key: "views", label: "Views", color: PALETTE[0] },
+            { key: "searches", label: "Searches", color: PALETTE[1] },
+            { key: "websiteClicks", label: "Website clicks", color: PALETTE[2] },
+          ]}
+        />
+        <TrendChart
+          title="Actions over time"
+          subtitle="Directions, calls & interactions"
+          data={report.daily}
+          series={[
+            { key: "directions", label: "Directions", color: PALETTE[3] },
+            { key: "calls", label: "Phone calls", color: PALETTE[1] },
+            { key: "interactions", label: "Interactions", color: PALETTE[4] },
+          ]}
+        />
+      </div>
+
+      {/* Find you + actions breakdown */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <FindYouDonut slices={report.findYou} />
+        <ActionsBreakdown slices={report.actions} />
+      </div>
+
+      {/* Queries + reviews */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <SearchKeywords keywords={report.searchKeywords} />
+        <ReviewsSummary reviews={report.reviews} />
+      </div>
+
+      {/* Monthly snapshot */}
+      <MonthlySnapshot rows={report.monthly} totals={report.totals} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup flow
+// ---------------------------------------------------------------------------
+
+function SetupPanel({
+  siteId,
+  onLinked,
+}: {
+  siteId: string;
+  onLinked: () => void;
+}) {
+  const [locations, setLocations] = useState<LocationOption[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchLocations() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/gbp/locations`);
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to list locations");
+      setLocations(json.locations as LocationOption[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to list locations");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function selectLocation(loc: LocationOption) {
+    setSaving(loc.name);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/gbp/locations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location: loc.name, label: loc.title }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error ?? "Failed to link location");
+      }
+      onLinked();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to link location");
+      setSaving(null);
+    }
+  }
+
+  return (
+    <div className="panel p-6">
+      <div className="flex items-start gap-3">
+        <div className="rounded-xl bg-primary/15 p-2">
+          <MapPin className="size-5 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+            Link a Google Business Profile
+          </h3>
+          <p className="mt-1 max-w-xl text-atom-body text-muted-foreground">
+            Choose which Business Profile location this site tracks. Metrics are
+            pulled from the Business Profile Performance API using your connected
+            Google account.
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-danger/30 bg-danger/5 p-3 text-sm text-foreground">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-danger" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {locations === null ? (
+        <button
+          type="button"
+          onClick={fetchLocations}
+          disabled={loading}
+          className="mt-5 flex items-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+        >
+          {loading ? <Loader2 className="size-4 animate-spin" /> : <MapPin className="size-4" />}
+          Find my locations
+        </button>
+      ) : locations.length === 0 ? (
+        <p className="mt-5 text-atom-body text-muted-foreground">
+          No Business Profile locations were found on your Google account.
+        </p>
+      ) : (
+        <div className="mt-5 space-y-2">
+          {locations.map((loc) => (
+            <button
+              key={loc.name}
+              type="button"
+              onClick={() => selectLocation(loc)}
+              disabled={saving !== null}
+              className="flex w-full items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition hover:border-primary/50 hover:bg-muted disabled:opacity-60"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium text-foreground">{loc.title}</p>
+                {loc.address && (
+                  <p className="truncate text-atom-caption text-muted-foreground">
+                    {loc.address}
+                  </p>
+                )}
+              </div>
+              {saving === loc.name ? (
+                <Loader2 className="size-4 shrink-0 animate-spin text-primary" />
+              ) : (
+                <Check className="size-4 shrink-0 text-muted-foreground" />
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Charts + panels
+// ---------------------------------------------------------------------------
+
+function TrendChart({
+  title,
+  subtitle,
+  data,
+  series,
+}: {
+  title: string;
+  subtitle: string;
+  data: DailyPoint[];
+  series: { key: keyof Totals; label: string; color: string }[];
+}) {
+  return (
+    <div className="panel p-5 sm:p-6">
+      <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+            {title}
+          </h3>
+          <p className="text-atom-caption text-muted-foreground">{subtitle}</p>
+        </div>
+        <div className="flex flex-wrap gap-4 text-atom-caption">
+          {series.map((s) => (
+            <span key={s.key} className="inline-flex items-center gap-2 text-muted-foreground">
+              <span className="size-2 rounded-full" style={{ background: s.color }} />
+              {s.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={280}>
+        <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <defs>
+            {series.map((s) => (
+              <linearGradient key={s.key} id={`gbp-${title}-${s.key}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={s.color} stopOpacity={0.24} />
+                <stop offset="100%" stopColor={s.color} stopOpacity={0} />
+              </linearGradient>
+            ))}
+          </defs>
+          <CartesianGrid stroke={GRID} strokeDasharray="4 6" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatAxisDate}
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            minTickGap={28}
+          />
+          <YAxis tick={{ fill: AXIS, fontSize: 11 }} axisLine={false} tickLine={false} width={40} />
+          <Tooltip
+            contentStyle={TOOLTIP_STYLE}
+            labelFormatter={(label) => formatAxisDate(String(label))}
+            formatter={(value, name) => [
+              typeof value === "number" ? value.toLocaleString() : value,
+              String(name),
+            ]}
+          />
+          {series.map((s) => (
+            <Area
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              name={s.label}
+              stroke={s.color}
+              fill={`url(#gbp-${title}-${s.key})`}
+              strokeWidth={2}
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function FindYouDonut({ slices }: { slices: Slice[] }) {
+  const total = slices.reduce((a, s) => a + s.value, 0);
+
+  return (
+    <div className="panel p-5 sm:p-6">
+      <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+        How customers find you
+      </h3>
+      <p className="mb-4 text-atom-caption text-muted-foreground">
+        Profile impressions by surface &amp; device
+      </p>
+
+      {total === 0 ? (
+        <EmptyBlock label="No impression data for this period" />
+      ) : (
+        <div className="flex flex-col items-center gap-6 sm:flex-row">
+          <ResponsiveContainer width={180} height={180}>
+            <PieChart>
+              <Pie
+                data={slices}
+                dataKey="value"
+                nameKey="label"
+                innerRadius={54}
+                outerRadius={82}
+                paddingAngle={2}
+                stroke="none"
+              >
+                {slices.map((_, i) => (
+                  <Cell key={i} fill={PALETTE[i % PALETTE.length]} />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={TOOLTIP_STYLE}
+                formatter={(value) => (typeof value === "number" ? value.toLocaleString() : value)}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className="flex-1 space-y-2">
+            {slices.map((s, i) => (
+              <div key={s.label} className="flex items-center justify-between gap-3 text-sm">
+                <span className="inline-flex items-center gap-2 text-muted-foreground">
+                  <span
+                    className="size-2.5 rounded-full"
+                    style={{ background: PALETTE[i % PALETTE.length] }}
+                  />
+                  {s.label}
+                </span>
+                <span className="font-data font-semibold text-foreground">
+                  {Math.round((s.value / total) * 100)}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActionsBreakdown({ slices }: { slices: Slice[] }) {
+  const total = slices.reduce((a, s) => a + s.value, 0);
+  const max = Math.max(1, ...slices.map((s) => s.value));
+
+  return (
+    <div className="panel p-5 sm:p-6">
+      <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+        Customer actions breakdown
+      </h3>
+      <p className="mb-4 text-atom-caption text-muted-foreground">
+        Share of total customer interactions
+      </p>
+
+      {total === 0 ? (
+        <EmptyBlock label="No customer actions for this period" />
+      ) : (
+        <div className="space-y-3">
+          {slices.map((s, i) => (
+            <div key={s.label}>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">{s.label}</span>
+                <span className="font-data font-semibold text-foreground">
+                  {s.value.toLocaleString()}{" "}
+                  <span className="text-muted-foreground">
+                    ({Math.round((s.value / total) * 100)}%)
+                  </span>
+                </span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${(s.value / max) * 100}%`,
+                    background: PALETTE[i % PALETTE.length],
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SearchKeywords({ keywords }: { keywords: SearchKeyword[] }) {
+  return (
+    <div className="panel p-5 sm:p-6">
+      <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+        Top search queries
+      </h3>
+      <p className="mb-4 text-atom-caption text-muted-foreground">
+        Searches that surfaced your profile
+      </p>
+
+      {keywords.length === 0 ? (
+        <EmptyBlock label="No search query data for this period" />
+      ) : (
+        <div className="space-y-1">
+          {keywords.map((k, i) => (
+            <div
+              key={k.keyword}
+              className="flex items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm hover:bg-muted"
+            >
+              <span className="inline-flex min-w-0 items-center gap-3">
+                <span className="w-4 shrink-0 text-right font-data text-muted-foreground">
+                  {i + 1}
+                </span>
+                <span className="truncate text-foreground">{k.keyword}</span>
+              </span>
+              <span className="font-data font-semibold text-foreground">
+                {k.approximate ? "≈" : ""}
+                {k.impressions.toLocaleString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReviewsSummary({ reviews }: { reviews: Reviews | null }) {
+  return (
+    <div className="panel p-5 sm:p-6">
+      <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+        Customer reviews
+      </h3>
+      <p className="mb-4 text-atom-caption text-muted-foreground">
+        Rating distribution across recent reviews
+      </p>
+
+      {!reviews || reviews.totalReviews === 0 ? (
+        <EmptyBlock label="Reviews are unavailable for this profile" />
+      ) : (
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+          <div className="text-center">
+            <p className="font-heading text-atom-display1 font-semibold text-foreground">
+              {reviews.averageRating.toFixed(1)}
+            </p>
+            <div className="mt-1 flex justify-center gap-0.5">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <Star
+                  key={n}
+                  className={cn(
+                    "size-4",
+                    n <= Math.round(reviews.averageRating)
+                      ? "fill-warning text-warning"
+                      : "text-muted-foreground/40"
+                  )}
+                />
+              ))}
+            </div>
+            <p className="mt-1 text-atom-caption text-muted-foreground">
+              {reviews.totalReviews.toLocaleString()} reviews
+            </p>
+          </div>
+          <div className="flex-1 space-y-1.5">
+            {[5, 4, 3, 2, 1].map((star) => {
+              const count = reviews.distribution[String(star)] ?? 0;
+              const pct = reviews.totalReviews
+                ? (count / reviews.totalReviews) * 100
+                : 0;
+              return (
+                <div key={star} className="flex items-center gap-2 text-xs">
+                  <span className="w-3 text-muted-foreground">{star}</span>
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-warning"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <span className="w-8 text-right font-data text-muted-foreground">
+                    {Math.round(pct)}%
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MonthlySnapshot({ rows, totals }: { rows: MonthlyRow[]; totals: Totals }) {
+  return (
+    <div className="panel overflow-hidden">
+      <div className="border-b border-border p-5 sm:p-6">
+        <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+          Monthly performance snapshot
+        </h3>
+        <p className="text-atom-caption text-muted-foreground">
+          Aggregated metrics per month
+        </p>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="p-6">
+          <EmptyBlock label="No monthly data for this period" />
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-atom-caption uppercase tracking-[0.1em] text-muted-foreground">
+                <th className="px-5 py-3 font-semibold">Month</th>
+                <th className="px-5 py-3 text-right font-semibold">Views</th>
+                <th className="px-5 py-3 text-right font-semibold">Searches</th>
+                <th className="px-5 py-3 text-right font-semibold">Clicks</th>
+                <th className="px-5 py-3 text-right font-semibold">Directions</th>
+                <th className="px-5 py-3 text-right font-semibold">Calls</th>
+                <th className="px-5 py-3 text-right font-semibold">Interactions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.month} className="border-b border-border/50 hover:bg-muted/40">
+                  <td className="px-5 py-2.5 font-medium text-foreground">{row.label}</td>
+                  <td className="px-5 py-2.5 text-right font-data text-foreground">{row.views.toLocaleString()}</td>
+                  <td className="px-5 py-2.5 text-right font-data text-foreground">{row.searches.toLocaleString()}</td>
+                  <td className="px-5 py-2.5 text-right font-data text-foreground">{row.websiteClicks.toLocaleString()}</td>
+                  <td className="px-5 py-2.5 text-right font-data text-foreground">{row.directions.toLocaleString()}</td>
+                  <td className="px-5 py-2.5 text-right font-data text-foreground">{row.calls.toLocaleString()}</td>
+                  <td className="px-5 py-2.5 text-right font-data text-foreground">{row.interactions.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="bg-muted/40 font-semibold">
+                <td className="px-5 py-3 text-foreground">Total</td>
+                <td className="px-5 py-3 text-right font-data text-foreground">{totals.views.toLocaleString()}</td>
+                <td className="px-5 py-3 text-right font-data text-foreground">{totals.searches.toLocaleString()}</td>
+                <td className="px-5 py-3 text-right font-data text-foreground">{totals.websiteClicks.toLocaleString()}</td>
+                <td className="px-5 py-3 text-right font-data text-foreground">{totals.directions.toLocaleString()}</td>
+                <td className="px-5 py-3 text-right font-data text-foreground">{totals.calls.toLocaleString()}</td>
+                <td className="px-5 py-3 text-right font-data text-foreground">{totals.interactions.toLocaleString()}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyBlock({ label }: { label: string }) {
+  return (
+    <div className="flex h-32 items-center justify-center text-center text-atom-body text-muted-foreground">
+      {label}
+    </div>
+  );
+}

--- a/components/research/keyword-save-panel.tsx
+++ b/components/research/keyword-save-panel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Bookmark, BookmarkCheck, X, Plus } from "lucide-react";
+
+interface KeywordSavePanelProps {
+  siteId: string;
+  query: string;
+  initialSaved: boolean;
+  initialTags: string[];
+  initialNotes: string;
+}
+
+export function KeywordSavePanel({
+  siteId,
+  query,
+  initialSaved,
+  initialTags,
+  initialNotes,
+}: KeywordSavePanelProps) {
+  const router = useRouter();
+  const [saved, setSaved] = useState(initialSaved);
+  const [tags, setTags] = useState<string[]>(initialTags);
+  const [notes, setNotes] = useState(initialNotes);
+  const [tagInput, setTagInput] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function addTag(raw: string) {
+    const tag = raw.trim();
+    if (!tag) return;
+    if (tags.some((t) => t.toLowerCase() === tag.toLowerCase())) {
+      setTagInput("");
+      return;
+    }
+    setTags([...tags, tag]);
+    setTagInput("");
+  }
+
+  function removeTag(tag: string) {
+    setTags(tags.filter((t) => t !== tag));
+  }
+
+  async function persist(nextTags: string[], nextNotes: string) {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/saved-keywords`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query,
+          notes: nextNotes.trim() || undefined,
+          tags: nextTags,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save keyword");
+      setSaved(true);
+      router.refresh();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function unsave() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/saved-keywords`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query }),
+      });
+      if (!res.ok) throw new Error("Failed to remove keyword");
+      setSaved(false);
+      setTags([]);
+      setNotes("");
+      router.refresh();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="panel p-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+            Tracking
+          </h3>
+          <p className="text-atom-caption text-muted-foreground">
+            {saved ? "Saved to your tracked keywords" : "Not tracked yet"}
+          </p>
+        </div>
+        {saved ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={unsave}
+            disabled={loading}
+            className="text-danger hover:bg-danger/10"
+          >
+            <BookmarkCheck className="size-3.5" />
+            Saved
+          </Button>
+        ) : (
+          <Button size="sm" onClick={() => persist(tags, notes)} disabled={loading}>
+            <Bookmark className="size-3.5" />
+            Save keyword
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="mb-1.5 block text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+            Tags
+          </label>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/12 px-2.5 py-1 text-xs font-medium text-primary"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => removeTag(tag)}
+                  className="text-primary/70 transition hover:text-primary"
+                  aria-label={`Remove tag ${tag}`}
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+            <div className="inline-flex items-center gap-1">
+              <input
+                type="text"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === ",") {
+                    e.preventDefault();
+                    addTag(tagInput);
+                  }
+                }}
+                placeholder="Add tag"
+                className="h-7 w-24 rounded-lg border border-border bg-card px-2.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+              {tagInput.trim() && (
+                <button
+                  type="button"
+                  onClick={() => addTag(tagInput)}
+                  className="rounded-full p-1 text-muted-foreground transition hover:bg-muted/40 hover:text-foreground"
+                  aria-label="Add tag"
+                >
+                  <Plus className="size-3.5" />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+            Notes
+          </label>
+          <input
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Target page, intent…"
+            className="h-8 w-full rounded-lg border border-border bg-card px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+        </div>
+
+        <Button
+          size="sm"
+          onClick={() => persist(tags, notes)}
+          disabled={loading}
+          className="w-full"
+        >
+          {loading ? "Saving…" : saved ? "Update tags & notes" : "Save keyword"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/research/rank-history-chart.tsx
+++ b/components/research/rank-history-chart.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  Area,
+  ComposedChart,
+  CartesianGrid,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export interface RankHistoryPoint {
+  date: string; // YYYY-MM-DD
+  position: number;
+  clicks: number;
+  impressions: number;
+}
+
+function formatAxisDate(value: string) {
+  const d = new Date(`${value}T00:00:00Z`);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+const PRIMARY = "#A78BFA";
+const SIGNAL = "#34D399";
+const AXIS = "#71717A";
+const GRID = "rgba(255,255,255,0.06)";
+
+export function RankHistoryChart({ data }: { data: RankHistoryPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="panel flex h-72 flex-col items-center justify-center gap-2">
+        <p className="font-heading text-atom-subheader font-medium text-foreground">
+          No rank history yet
+        </p>
+        <p className="text-atom-body text-muted-foreground">
+          Position data will appear as Search Console history accumulates.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel p-5 sm:p-6">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h3 className="font-heading text-atom-subheader font-semibold text-foreground">
+            Rank history
+          </h3>
+          <p className="text-atom-caption text-muted-foreground">
+            Average position &amp; clicks · last {data.length} days
+          </p>
+        </div>
+        <div className="flex gap-4 text-atom-caption">
+          <span className="inline-flex items-center gap-2 text-muted-foreground">
+            <span className="size-2 rounded-full" style={{ background: PRIMARY }} /> Position
+          </span>
+          <span className="inline-flex items-center gap-2 text-muted-foreground">
+            <span className="size-2 rounded-full" style={{ background: SIGNAL }} /> Clicks
+          </span>
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id="rankClicksFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={SIGNAL} stopOpacity={0.18} />
+              <stop offset="100%" stopColor={SIGNAL} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke={GRID} strokeDasharray="4 6" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatAxisDate}
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            minTickGap={28}
+          />
+          {/* Position axis is reversed: rank 1 sits at the top. */}
+          <YAxis
+            yAxisId="position"
+            reversed
+            domain={[1, "dataMax"]}
+            allowDecimals={false}
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={36}
+          />
+          <YAxis
+            yAxisId="clicks"
+            orientation="right"
+            tick={{ fill: AXIS, fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={40}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "#161618",
+              border: "1px solid rgba(255,255,255,0.08)",
+              borderRadius: 14,
+              fontSize: 12,
+              boxShadow: "0 16px 40px rgba(0,0,0,0.55)",
+              color: "#F4F4F5",
+            }}
+            labelFormatter={(label) => formatAxisDate(String(label))}
+            formatter={(value, name) => {
+              if (name === "position") {
+                return [
+                  typeof value === "number" ? value.toFixed(1) : value,
+                  "Position",
+                ];
+              }
+              return [
+                typeof value === "number" ? value.toLocaleString() : value,
+                "Clicks",
+              ];
+            }}
+          />
+          <Area
+            yAxisId="clicks"
+            type="monotone"
+            dataKey="clicks"
+            stroke={SIGNAL}
+            fill="url(#rankClicksFill)"
+            strokeWidth={2}
+            isAnimationActive={false}
+          />
+          <Line
+            yAxisId="position"
+            type="monotone"
+            dataKey="position"
+            stroke={PRIMARY}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/components/sites/keywords-table.tsx
+++ b/components/sites/keywords-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useDeferredValue, useMemo, useState } from "react";
 import type { KeywordRow } from "@/lib/seo-metrics";
 import {
@@ -41,7 +42,13 @@ function parseMin(value: string): number | null {
   return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
-export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
+export function KeywordsTable({
+  keywords,
+  siteId,
+}: {
+  keywords: KeywordRow[];
+  siteId: string;
+}) {
   const [search, setSearch] = useState("");
   const [position, setPosition] = useState<PositionFilter>("all");
   const [minClicks, setMinClicks] = useState("");
@@ -221,9 +228,12 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
               className="transition-colors hover:bg-muted/25"
             >
               <td className="max-w-md px-4 py-3">
-                <span className="font-medium text-foreground">
+                <Link
+                  href={`/sites/${siteId}/keywords/detail?query=${encodeURIComponent(keyword.query)}`}
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-2 transition hover:decoration-primary"
+                >
                   {keyword.query}
-                </span>
+                </Link>
               </td>
               <td className="px-4 py-3 text-right">
                 <PositionBadge position={keyword.position} />

--- a/components/sites/saved-keyword-actions.tsx
+++ b/components/sites/saved-keyword-actions.tsx
@@ -10,6 +10,7 @@ export function SaveKeywordForm({ siteId }: { siteId: string }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [notes, setNotes] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
   const [loading, setLoading] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -17,14 +18,23 @@ export function SaveKeywordForm({ siteId }: { siteId: string }) {
     if (!query.trim()) return;
     setLoading(true);
     try {
+      const tags = tagsInput
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
       const res = await fetch(`/api/sites/${siteId}/saved-keywords`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query: query.trim(), notes: notes.trim() || undefined }),
+        body: JSON.stringify({
+          query: query.trim(),
+          notes: notes.trim() || undefined,
+          tags: tags.length > 0 ? tags : undefined,
+        }),
       });
       if (!res.ok) throw new Error("Failed to save keyword");
       setQuery("");
       setNotes("");
+      setTagsInput("");
       setOpen(false);
       router.refresh();
     } catch (err) {
@@ -54,6 +64,16 @@ export function SaveKeywordForm({ siteId }: { siteId: string }) {
           placeholder="e.g. seo tools"
           className="h-8 rounded-lg border border-border bg-card px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           autoFocus
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-[11px] text-muted-foreground">Tags (comma-separated)</label>
+        <input
+          type="text"
+          value={tagsInput}
+          onChange={(e) => setTagsInput(e.target.value)}
+          placeholder="brand, money, local"
+          className="h-8 rounded-lg border border-border bg-card px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
       <div>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -15,7 +15,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       authorization: {
         params: {
-          scope: "openid email profile https://www.googleapis.com/auth/webmasters.readonly",
+          scope:
+            "openid email profile https://www.googleapis.com/auth/webmasters.readonly https://www.googleapis.com/auth/business.manage",
           access_type: "offline",
           prompt: "consent",
         },

--- a/lib/google/gbp-client.ts
+++ b/lib/google/gbp-client.ts
@@ -1,0 +1,622 @@
+import { getAccessToken } from "./google-auth";
+
+const ACCOUNTS_API = "https://mybusinessaccountmanagement.googleapis.com/v1";
+const INFO_API = "https://mybusinessbusinessinformation.googleapis.com/v1";
+const PERF_API = "https://businessprofileperformance.googleapis.com/v1";
+const LEGACY_API = "https://mybusiness.googleapis.com/v4";
+
+// Daily metrics we request from the Business Profile Performance API.
+const DAILY_METRICS = [
+  "BUSINESS_IMPRESSIONS_DESKTOP_MAPS",
+  "BUSINESS_IMPRESSIONS_DESKTOP_SEARCH",
+  "BUSINESS_IMPRESSIONS_MOBILE_MAPS",
+  "BUSINESS_IMPRESSIONS_MOBILE_SEARCH",
+  "WEBSITE_CLICKS",
+  "CALL_CLICKS",
+  "BUSINESS_DIRECTION_REQUESTS",
+  "BUSINESS_CONVERSATIONS",
+  "BUSINESS_BOOKINGS",
+] as const;
+
+type DailyMetric = (typeof DAILY_METRICS)[number];
+
+export interface GBPLocation {
+  /** Resource name, e.g. "locations/12345678901234567890" */
+  name: string;
+  title: string;
+  address: string | null;
+  phone: string | null;
+}
+
+/** Raw per-day metric values as stored in the database. */
+export interface GBPRawDaily {
+  date: string; // YYYY-MM-DD
+  desktopMaps: number;
+  desktopSearch: number;
+  mobileMaps: number;
+  mobileSearch: number;
+  websiteClicks: number;
+  callClicks: number;
+  directionRequests: number;
+  conversations: number;
+  bookings: number;
+}
+
+export interface GBPDailyPoint {
+  date: string; // YYYY-MM-DD
+  views: number;
+  searches: number;
+  websiteClicks: number;
+  directions: number;
+  calls: number;
+  interactions: number;
+}
+
+export interface GBPMonthlyRow {
+  month: string; // YYYY-MM
+  label: string; // "Jan 2026"
+  views: number;
+  searches: number;
+  websiteClicks: number;
+  directions: number;
+  calls: number;
+  interactions: number;
+}
+
+export interface GBPTotals {
+  views: number;
+  searches: number;
+  websiteClicks: number;
+  directions: number;
+  calls: number;
+  interactions: number;
+}
+
+export interface GBPBreakdownSlice {
+  label: string;
+  value: number;
+}
+
+export interface GBPSearchKeyword {
+  keyword: string;
+  impressions: number;
+  approximate: boolean;
+}
+
+export interface GBPReviews {
+  averageRating: number;
+  totalReviews: number;
+  distribution: Record<1 | 2 | 3 | 4 | 5, number>;
+}
+
+export interface GBPSupplemental {
+  searchKeywords: GBPSearchKeyword[];
+  reviews: GBPReviews | null;
+}
+
+export interface GBPReport {
+  location: string;
+  periodDays: number;
+  startDate: string;
+  endDate: string;
+  totals: GBPTotals;
+  previousTotals: GBPTotals;
+  deltas: GBPTotals; // percentage change (0-1 scale, e.g. 0.638 = +63.8%)
+  daily: GBPDailyPoint[];
+  monthly: GBPMonthlyRow[];
+  findYou: GBPBreakdownSlice[]; // "How customers find you"
+  actions: GBPBreakdownSlice[]; // "Customer actions breakdown"
+  searchKeywords: GBPSearchKeyword[];
+  reviews: GBPReviews | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function gbpFetch<T>(url: string, accessToken: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Business Profile API error: ${response.status} ${response.statusText}${
+        body ? ` — ${body.slice(0, 500)}` : ""
+      }`
+    );
+  }
+  return (await response.json()) as T;
+}
+
+function toDateKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function monthLabel(monthKey: string): string {
+  const [year, month] = monthKey.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** Percentage change on a 0-1 scale. Returns 0 when there is no prior data. */
+function pctChange(current: number, previous: number): number {
+  if (!previous) return current > 0 ? 1 : 0;
+  return (current - previous) / previous;
+}
+
+function emptyTotals(): GBPTotals {
+  return {
+    views: 0,
+    searches: 0,
+    websiteClicks: 0,
+    directions: 0,
+    calls: 0,
+    interactions: 0,
+  };
+}
+
+/** Derives the aggregated per-day point shown in charts from a raw row. */
+function rawToDailyPoint(r: GBPRawDaily): GBPDailyPoint {
+  const searches = r.desktopSearch + r.mobileSearch;
+  const maps = r.desktopMaps + r.mobileMaps;
+  return {
+    date: r.date,
+    views: searches + maps,
+    searches,
+    websiteClicks: r.websiteClicks,
+    directions: r.directionRequests,
+    calls: r.callClicks,
+    interactions:
+      r.websiteClicks + r.directionRequests + r.callClicks + r.conversations + r.bookings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Location discovery
+// ---------------------------------------------------------------------------
+
+interface AccountsResponse {
+  accounts?: { name: string }[];
+}
+
+interface LocationsResponse {
+  locations?: {
+    name: string;
+    title?: string;
+    phoneNumbers?: { primaryPhone?: string };
+    storefrontAddress?: { addressLines?: string[]; locality?: string; administrativeArea?: string };
+  }[];
+  nextPageToken?: string;
+}
+
+/**
+ * Lists every Business Profile location the user can manage across all of
+ * their accounts.
+ */
+export async function listGBPLocations(userId: string): Promise<GBPLocation[]> {
+  const accessToken = await getAccessToken(userId);
+
+  const accountsData = await gbpFetch<AccountsResponse>(
+    `${ACCOUNTS_API}/accounts`,
+    accessToken
+  );
+  const accounts = accountsData.accounts ?? [];
+
+  const readMask = "name,title,phoneNumbers,storefrontAddress";
+  const locations: GBPLocation[] = [];
+
+  for (const account of accounts) {
+    let pageToken: string | undefined;
+    do {
+      const url = new URL(`${INFO_API}/${account.name}/locations`);
+      url.searchParams.set("readMask", readMask);
+      url.searchParams.set("pageSize", "100");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+
+      const data = await gbpFetch<LocationsResponse>(url.toString(), accessToken);
+      for (const loc of data.locations ?? []) {
+        const addr = loc.storefrontAddress;
+        const address = addr
+          ? [addr.addressLines?.join(" "), addr.locality, addr.administrativeArea]
+              .filter(Boolean)
+              .join(", ")
+          : null;
+        locations.push({
+          name: loc.name,
+          title: loc.title ?? loc.name,
+          address: address || null,
+          phone: loc.phoneNumbers?.primaryPhone ?? null,
+        });
+      }
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+  }
+
+  return locations;
+}
+
+// ---------------------------------------------------------------------------
+// Performance metrics (raw daily fetch)
+// ---------------------------------------------------------------------------
+
+interface MultiTimeSeriesResponse {
+  multiDailyMetricTimeSeries?: {
+    dailyMetricTimeSeries?: {
+      dailyMetric?: string;
+      timeSeries?: {
+        datedValues?: {
+          date?: { year: number; month: number; day: number };
+          value?: string;
+        }[];
+      };
+    };
+  }[];
+}
+
+/**
+ * Fetches per-day values for every metric in DAILY_METRICS between two dates.
+ * Returns a map of `metric -> (YYYY-MM-DD -> value)`.
+ */
+async function fetchDailyMetrics(
+  accessToken: string,
+  location: string,
+  start: Date,
+  end: Date
+): Promise<Map<DailyMetric, Map<string, number>>> {
+  const url = new URL(
+    `${PERF_API}/${location}:fetchMultiDailyMetricsTimeSeries`
+  );
+  for (const metric of DAILY_METRICS) {
+    url.searchParams.append("dailyMetrics", metric);
+  }
+  url.searchParams.set("dailyRange.start_date.year", String(start.getUTCFullYear()));
+  url.searchParams.set("dailyRange.start_date.month", String(start.getUTCMonth() + 1));
+  url.searchParams.set("dailyRange.start_date.day", String(start.getUTCDate()));
+  url.searchParams.set("dailyRange.end_date.year", String(end.getUTCFullYear()));
+  url.searchParams.set("dailyRange.end_date.month", String(end.getUTCMonth() + 1));
+  url.searchParams.set("dailyRange.end_date.day", String(end.getUTCDate()));
+
+  const data = await gbpFetch<MultiTimeSeriesResponse>(url.toString(), accessToken);
+
+  const result = new Map<DailyMetric, Map<string, number>>();
+  for (const metric of DAILY_METRICS) result.set(metric, new Map());
+
+  for (const entry of data.multiDailyMetricTimeSeries ?? []) {
+    const series = entry.dailyMetricTimeSeries;
+    const metric = series?.dailyMetric as DailyMetric | undefined;
+    if (!metric || !result.has(metric)) continue;
+    const bucket = result.get(metric)!;
+    for (const dv of series?.timeSeries?.datedValues ?? []) {
+      if (!dv.date) continue;
+      const key = `${dv.date.year}-${String(dv.date.month).padStart(2, "0")}-${String(
+        dv.date.day
+      ).padStart(2, "0")}`;
+      bucket.set(key, Number(dv.value ?? 0));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Fetches raw daily metrics for a location over a date range, returned as one
+ * row per day for persistence.
+ */
+export async function fetchGBPRawDaily(
+  userId: string,
+  location: string,
+  start: Date,
+  end: Date
+): Promise<GBPRawDaily[]> {
+  const accessToken = await getAccessToken(userId);
+  const metrics = await fetchDailyMetrics(accessToken, location, start, end);
+  const get = (m: DailyMetric, day: string) => metrics.get(m)?.get(day) ?? 0;
+
+  const rows: GBPRawDaily[] = [];
+  for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+    const day = toDateKey(d);
+    rows.push({
+      date: day,
+      desktopMaps: get("BUSINESS_IMPRESSIONS_DESKTOP_MAPS", day),
+      desktopSearch: get("BUSINESS_IMPRESSIONS_DESKTOP_SEARCH", day),
+      mobileMaps: get("BUSINESS_IMPRESSIONS_MOBILE_MAPS", day),
+      mobileSearch: get("BUSINESS_IMPRESSIONS_MOBILE_SEARCH", day),
+      websiteClicks: get("WEBSITE_CLICKS", day),
+      callClicks: get("CALL_CLICKS", day),
+      directionRequests: get("BUSINESS_DIRECTION_REQUESTS", day),
+      conversations: get("BUSINESS_CONVERSATIONS", day),
+      bookings: get("BUSINESS_BOOKINGS", day),
+    });
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+function sumTotals(points: GBPDailyPoint[]): GBPTotals {
+  return points.reduce((acc, p) => {
+    acc.views += p.views;
+    acc.searches += p.searches;
+    acc.websiteClicks += p.websiteClicks;
+    acc.directions += p.directions;
+    acc.calls += p.calls;
+    acc.interactions += p.interactions;
+    return acc;
+  }, emptyTotals());
+}
+
+function buildMonthly(points: GBPDailyPoint[]): GBPMonthlyRow[] {
+  const byMonth = new Map<string, GBPMonthlyRow>();
+  for (const p of points) {
+    const month = p.date.slice(0, 7);
+    const row =
+      byMonth.get(month) ??
+      ({
+        month,
+        label: monthLabel(month),
+        views: 0,
+        searches: 0,
+        websiteClicks: 0,
+        directions: 0,
+        calls: 0,
+        interactions: 0,
+      } satisfies GBPMonthlyRow);
+    row.views += p.views;
+    row.searches += p.searches;
+    row.websiteClicks += p.websiteClicks;
+    row.directions += p.directions;
+    row.calls += p.calls;
+    row.interactions += p.interactions;
+    byMonth.set(month, row);
+  }
+  return [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month));
+}
+
+// ---------------------------------------------------------------------------
+// Search keywords (monthly)
+// ---------------------------------------------------------------------------
+
+interface SearchKeywordsResponse {
+  searchKeywordsCounts?: {
+    searchKeyword?: string;
+    insightsValue?: { value?: string; threshold?: string };
+  }[];
+}
+
+async function fetchSearchKeywords(
+  accessToken: string,
+  location: string,
+  start: Date,
+  end: Date
+): Promise<GBPSearchKeyword[]> {
+  const url = new URL(`${PERF_API}/${location}/searchkeywords/impressions/monthly`);
+  url.searchParams.set("monthlyRange.start_month.year", String(start.getUTCFullYear()));
+  url.searchParams.set("monthlyRange.start_month.month", String(start.getUTCMonth() + 1));
+  url.searchParams.set("monthlyRange.end_month.year", String(end.getUTCFullYear()));
+  url.searchParams.set("monthlyRange.end_month.month", String(end.getUTCMonth() + 1));
+
+  const data = await gbpFetch<SearchKeywordsResponse>(url.toString(), accessToken);
+
+  const aggregated = new Map<string, { impressions: number; approximate: boolean }>();
+  for (const row of data.searchKeywordsCounts ?? []) {
+    const keyword = row.searchKeyword?.trim();
+    if (!keyword) continue;
+    const exact = row.insightsValue?.value;
+    const threshold = row.insightsValue?.threshold;
+    const impressions = Number(exact ?? threshold ?? 0);
+    const existing = aggregated.get(keyword) ?? { impressions: 0, approximate: false };
+    existing.impressions += impressions;
+    existing.approximate = existing.approximate || exact == null;
+    aggregated.set(keyword, existing);
+  }
+
+  return [...aggregated.entries()]
+    .map(([keyword, v]) => ({ keyword, ...v }))
+    .sort((a, b) => b.impressions - a.impressions)
+    .slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Reviews (best-effort; legacy v4 endpoint)
+// ---------------------------------------------------------------------------
+
+interface ReviewsResponse {
+  reviews?: { starRating?: string }[];
+  averageRating?: number;
+  totalReviewCount?: number;
+}
+
+const STAR_MAP: Record<string, 1 | 2 | 3 | 4 | 5> = {
+  ONE: 1,
+  TWO: 2,
+  THREE: 3,
+  FOUR: 4,
+  FIVE: 5,
+};
+
+async function fetchReviews(
+  accessToken: string,
+  accounts: { name: string }[],
+  location: string
+): Promise<GBPReviews | null> {
+  const locationId = location.split("/").pop();
+  if (!locationId) return null;
+
+  for (const account of accounts) {
+    try {
+      const url = `${LEGACY_API}/${account.name}/locations/${locationId}/reviews?pageSize=50`;
+      const data = await gbpFetch<ReviewsResponse>(url, accessToken);
+      const reviews = data.reviews ?? [];
+      const distribution: Record<1 | 2 | 3 | 4 | 5, number> = {
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 0,
+      };
+      for (const r of reviews) {
+        const star = r.starRating ? STAR_MAP[r.starRating] : undefined;
+        if (star) distribution[star] += 1;
+      }
+      return {
+        averageRating: data.averageRating ?? 0,
+        totalReviews: data.totalReviewCount ?? reviews.length,
+        distribution,
+      };
+    } catch {
+      // Try the next account; reviews are optional.
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetches the supplementary data (top search queries + reviews) that is not
+ * stored in the daily metrics table. Best-effort: failures degrade to
+ * empty/null rather than throwing.
+ */
+export async function fetchGBPSupplemental(
+  userId: string,
+  location: string,
+  start: Date,
+  end: Date
+): Promise<GBPSupplemental> {
+  const accessToken = await getAccessToken(userId);
+
+  const searchKeywords = await fetchSearchKeywords(accessToken, location, start, end).catch(
+    () => []
+  );
+
+  let reviews: GBPReviews | null = null;
+  try {
+    const accountsData = await gbpFetch<AccountsResponse>(
+      `${ACCOUNTS_API}/accounts`,
+      accessToken
+    );
+    reviews = await fetchReviews(accessToken, accountsData.accounts ?? [], location);
+  } catch {
+    reviews = null;
+  }
+
+  return { searchKeywords, reviews };
+}
+
+// ---------------------------------------------------------------------------
+// Report builder (pure — operates on stored rows)
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a full GBP progress report from raw daily rows. `currentRows` covers
+ * the reporting window; `previousRows` covers the immediately-prior window used
+ * for delta comparisons.
+ */
+export function buildGBPReport(params: {
+  location: string;
+  days: number;
+  startDate: string;
+  endDate: string;
+  currentRows: GBPRawDaily[];
+  previousRows: GBPRawDaily[];
+  supplemental: GBPSupplemental;
+}): GBPReport {
+  const { location, days, startDate, endDate, currentRows, previousRows, supplemental } =
+    params;
+
+  const daily = currentRows.map(rawToDailyPoint);
+  const totals = sumTotals(daily);
+  const previousTotals = sumTotals(previousRows.map(rawToDailyPoint));
+
+  const deltas: GBPTotals = {
+    views: pctChange(totals.views, previousTotals.views),
+    searches: pctChange(totals.searches, previousTotals.searches),
+    websiteClicks: pctChange(totals.websiteClicks, previousTotals.websiteClicks),
+    directions: pctChange(totals.directions, previousTotals.directions),
+    calls: pctChange(totals.calls, previousTotals.calls),
+    interactions: pctChange(totals.interactions, previousTotals.interactions),
+  };
+
+  const sumRaw = (pick: (r: GBPRawDaily) => number) =>
+    currentRows.reduce((a, r) => a + pick(r), 0);
+
+  const findYou: GBPBreakdownSlice[] = [
+    { label: "Mobile search", value: sumRaw((r) => r.mobileSearch) },
+    { label: "Desktop search", value: sumRaw((r) => r.desktopSearch) },
+    { label: "Maps", value: sumRaw((r) => r.mobileMaps + r.desktopMaps) },
+  ].filter((s) => s.value > 0);
+
+  const actions: GBPBreakdownSlice[] = [
+    { label: "Phone calls", value: totals.calls },
+    { label: "Website clicks", value: totals.websiteClicks },
+    { label: "Direction requests", value: totals.directions },
+    { label: "Messages", value: sumRaw((r) => r.conversations) },
+    { label: "Bookings", value: sumRaw((r) => r.bookings) },
+  ].filter((s) => s.value > 0);
+
+  return {
+    location,
+    periodDays: days,
+    startDate,
+    endDate,
+    totals,
+    previousTotals,
+    deltas,
+    daily,
+    monthly: buildMonthly(daily),
+    findYou,
+    actions,
+    searchKeywords: supplemental.searchKeywords,
+    reviews: supplemental.reviews,
+  };
+}
+
+/** The latest date the Performance API reliably has data for (~3 days ago). */
+export function gbpLatestDataDate(): Date {
+  const end = new Date();
+  end.setUTCDate(end.getUTCDate() - 3);
+  end.setUTCHours(0, 0, 0, 0);
+  return end;
+}
+
+/**
+ * Builds a report by fetching everything live from the API. Used as a fallback
+ * when no stored rows exist yet.
+ */
+export async function getGBPReport(
+  userId: string,
+  location: string,
+  days: number
+): Promise<GBPReport> {
+  const end = gbpLatestDataDate();
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+
+  const prevEnd = new Date(start);
+  prevEnd.setUTCDate(prevEnd.getUTCDate() - 1);
+  const prevStart = new Date(prevEnd);
+  prevStart.setUTCDate(prevStart.getUTCDate() - (days - 1));
+
+  const [rows, supplemental] = await Promise.all([
+    fetchGBPRawDaily(userId, location, prevStart, end),
+    fetchGBPSupplemental(userId, location, start, end),
+  ]);
+
+  const startKey = toDateKey(start);
+  const currentRows = rows.filter((r) => r.date >= startKey);
+  const previousRows = rows.filter((r) => r.date < startKey);
+
+  return buildGBPReport({
+    location,
+    days,
+    startDate: startKey,
+    endDate: toDateKey(end),
+    currentRows,
+    previousRows,
+    supplemental,
+  });
+}

--- a/lib/google/index.ts
+++ b/lib/google/index.ts
@@ -2,3 +2,4 @@ export * from "./google-auth";
 export * from "./gsc-client";
 export * from "./url-inspection-client";
 export * from "./pagespeed-client";
+export * from "./gbp-client";

--- a/lib/workers/gbp-sync.ts
+++ b/lib/workers/gbp-sync.ts
@@ -1,0 +1,104 @@
+import { db } from "@/lib/db";
+import { fetchGBPRawDaily, gbpLatestDataDate } from "@/lib/google";
+
+interface GBPSyncResult {
+  success: boolean;
+  daysUpserted: number;
+  startDate: string;
+  endDate: string;
+  error?: string;
+}
+
+/** How much history to backfill on each sync (roughly 18 months). */
+const SYNC_WINDOW_DAYS = 550;
+
+/**
+ * Syncs Google Business Profile daily metrics for a specific site into the
+ * GBPDailyMetric table. Fetches a rolling ~18-month window of raw daily values
+ * and upserts one row per day.
+ */
+export async function syncGBPDataForSite(
+  userId: string,
+  siteId: string,
+  daysBack: number = SYNC_WINDOW_DAYS
+): Promise<GBPSyncResult> {
+  try {
+    const site = await db.site.findUnique({
+      where: { id: siteId },
+      select: { userId: true, gbpLocation: true },
+    });
+
+    if (!site) {
+      throw new Error("Site not found");
+    }
+
+    if (site.userId !== userId) {
+      throw new Error("Unauthorized: Site does not belong to user");
+    }
+
+    if (!site.gbpLocation) {
+      throw new Error("Site does not have a Business Profile location linked");
+    }
+
+    const end = gbpLatestDataDate();
+    const start = new Date(end);
+    start.setUTCDate(start.getUTCDate() - (daysBack - 1));
+
+    console.log(`[GBP Sync] Starting sync for site ${siteId} (${site.gbpLocation})`);
+
+    const rows = await fetchGBPRawDaily(userId, site.gbpLocation, start, end);
+
+    let daysUpserted = 0;
+    for (const row of rows) {
+      const date = new Date(`${row.date}T00:00:00.000Z`);
+      try {
+        await db.gBPDailyMetric.upsert({
+          where: { siteId_date: { siteId, date } },
+          create: {
+            siteId,
+            date,
+            desktopMaps: row.desktopMaps,
+            desktopSearch: row.desktopSearch,
+            mobileMaps: row.mobileMaps,
+            mobileSearch: row.mobileSearch,
+            websiteClicks: row.websiteClicks,
+            callClicks: row.callClicks,
+            directionRequests: row.directionRequests,
+            conversations: row.conversations,
+            bookings: row.bookings,
+          },
+          update: {
+            desktopMaps: row.desktopMaps,
+            desktopSearch: row.desktopSearch,
+            mobileMaps: row.mobileMaps,
+            mobileSearch: row.mobileSearch,
+            websiteClicks: row.websiteClicks,
+            callClicks: row.callClicks,
+            directionRequests: row.directionRequests,
+            conversations: row.conversations,
+            bookings: row.bookings,
+          },
+        });
+        daysUpserted++;
+      } catch (error) {
+        console.warn(`[GBP Sync] Failed to upsert day ${row.date}`, error);
+      }
+    }
+
+    const startDate = start.toISOString().slice(0, 10);
+    const endDate = end.toISOString().slice(0, 10);
+    console.log(`[GBP Sync] Sync completed: ${daysUpserted} days (${startDate} to ${endDate})`);
+
+    return { success: true, daysUpserted, startDate, endDate };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    console.error(`[GBP Sync] Error syncing site ${siteId}:`, errorMessage);
+    return {
+      success: false,
+      daysUpserted: 0,
+      startDate: "",
+      endDate: "",
+      error: errorMessage,
+    };
+  }
+}

--- a/prisma/migrations/20260730120000_add_gbp_location/migration.sql
+++ b/prisma/migrations/20260730120000_add_gbp_location/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Site" ADD COLUMN     "gbpLocation" TEXT,
+ADD COLUMN     "gbpLabel" TEXT;

--- a/prisma/migrations/20260730130000_add_gbp_daily_metric/migration.sql
+++ b/prisma/migrations/20260730130000_add_gbp_daily_metric/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "GBPDailyMetric" (
+    "id" TEXT NOT NULL,
+    "siteId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "desktopMaps" INTEGER NOT NULL DEFAULT 0,
+    "desktopSearch" INTEGER NOT NULL DEFAULT 0,
+    "mobileMaps" INTEGER NOT NULL DEFAULT 0,
+    "mobileSearch" INTEGER NOT NULL DEFAULT 0,
+    "websiteClicks" INTEGER NOT NULL DEFAULT 0,
+    "callClicks" INTEGER NOT NULL DEFAULT 0,
+    "directionRequests" INTEGER NOT NULL DEFAULT 0,
+    "conversations" INTEGER NOT NULL DEFAULT 0,
+    "bookings" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "GBPDailyMetric_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GBPDailyMetric_siteId_date_idx" ON "GBPDailyMetric"("siteId", "date");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GBPDailyMetric_siteId_date_key" ON "GBPDailyMetric"("siteId", "date");
+
+-- AddForeignKey
+ALTER TABLE "GBPDailyMetric" ADD CONSTRAINT "GBPDailyMetric_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260730140000_add_saved_keyword_tags/migration.sql
+++ b/prisma/migrations/20260730140000_add_saved_keyword_tags/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SavedKeyword" ADD COLUMN "tags" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -175,6 +175,7 @@ model SavedKeyword {
   siteId    String
   query     String
   notes     String?
+  tags      String[] @default([])
   createdAt DateTime @default(now())
 
   site      Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,8 @@ model Site {
   userId      String
   domain      String   // e.g. "brandson.digital"
   gscProperty String?  // e.g. "sc-domain:brandson.digital"
+  gbpLocation String?  // Business Profile resource name, e.g. "locations/12345"
+  gbpLabel    String?  // Human-readable location title for display
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -96,6 +98,7 @@ model Site {
   alerts        Alert[]
   savedKeywords SavedKeyword[]
   rankSnapshots RankSnapshot[]
+  gbpMetrics    GBPDailyMetric[]
 
   @@unique([userId, domain])
 }
@@ -137,6 +140,32 @@ model Page {
   @@unique([siteId, url, date])
   @@index([siteId, date])
   @@index([siteId, url, date])
+}
+
+// ============ GBP (GOOGLE BUSINESS PROFILE) ============
+
+model GBPDailyMetric {
+  id                String   @id @default(cuid())
+  siteId            String
+  date              DateTime // Day of the data point (UTC midnight)
+
+  // Raw impression breakdown (surface x device)
+  desktopMaps       Int      @default(0)
+  desktopSearch     Int      @default(0)
+  mobileMaps        Int      @default(0)
+  mobileSearch      Int      @default(0)
+
+  // Customer actions
+  websiteClicks     Int      @default(0)
+  callClicks        Int      @default(0)
+  directionRequests Int      @default(0)
+  conversations     Int      @default(0)
+  bookings          Int      @default(0)
+
+  site              Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@unique([siteId, date])
+  @@index([siteId, date])
 }
 
 // ============ SAVED KEYWORDS ============

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,15 @@
     },
     "app/api/gsc/sync/route.ts": {
       "maxDuration": 60
+    },
+    "app/api/cron/gsc-sync/route.ts": {
+      "maxDuration": 300
     }
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/gsc-sync",
+      "schedule": "0 */6 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Rebased cleanly onto latest `main`. Two features:

- **Clickable keyword/page detail pages with tagging** — the Top Keywords list on the dashboard and the queries in the Keywords table now link to per-query detail pages (rank history, top landing page, save/tag panel). New `pages/detail` view too. Links are styled to be visually obvious (colored + underlined).
- **Business Profile (GBP) progress report + scheduled GSC/GBP sync** — new GBP client, progress report page/component, background sync worker, cron route, and Prisma models/migrations (`GbpLocation`, `GbpDailyMetric`, `SavedKeywordTag`).

## Conflict resolution notes (vs current main)
- **Google auth token refactor:** main's PR #6 deduped token logic into `lib/google/google-auth.ts` (incl. `ReauthRequiredError` on `invalid_grant`). This branch had introduced a parallel `lib/google/token.ts`. Kept `google-auth.ts` (the newer one), **dropped the duplicate `token.ts`**, and repointed all `gsc-client`/`gbp-client` imports to `getAccessToken`.
- **Keywords page:** main's PR #6 added the filterable `KeywordsTable`. Kept it, and **added the detail-page link into it** (query rendered as a link) so filtering + drill-down coexist, rather than reverting to the older inline table.

## Verification
- `tsc --noEmit` — clean
- `eslint` (changed files) — clean
- `next build` fails locally only on an unrelated native binary (`lightningcss.darwin-arm64.node`) missing on this Mac; unaffected on Linux/Vercel.