### PR TITLE
feat: publish multi-arch docker images to ghcr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ GOOGLE_CLIENT_SECRET=your-client-secret-here
 # Production (Vercel): set to https://your-app.vercel.app
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=generate-with-openssl-rand-hex-32
+# Required when running behind a reverse proxy such as Coolify
+AUTH_TRUST_HOST=true
 # AUTH_SECRET works as alias for Auth.js v5
 # AUTH_SECRET=
 

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ APP_SECRET=change-me-to-random-string
 
 # ============ DOCKER COMPOSE DB CREDENTIALS ============
 # These are referenced by docker-compose.yml — set your own for non-local deployments.
+# Override to pin a release or use an image built from a fork.
+# CRAWLSEO_IMAGE=ghcr.io/crawlseo/crawlseo:latest
 POSTGRES_USER=crawlseo
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=crawlseo

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build multi-architecture image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY package-lock.json ./
 # Keep the migration CLI in the image instead of downloading it through npx at
 # container startup. Reading the version from the lockfile keeps it aligned with
 # the generated Prisma client.
-RUN npm install --global "prisma@$(node -p \"require('./package-lock.json').packages['node_modules/prisma'].version\")" \
+RUN npm install --global "prisma@$(node -p "require('./package-lock.json').packages['node_modules/prisma'].version")" \
     && npm cache clean --force
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -38,4 +38,5 @@ COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 CMD ["sh", "-c", "prisma migrate deploy && node server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,25 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Next.js evaluates the Auth.js configuration while collecting build output.
+# These non-secret placeholders keep the image build independent of runtime
+# configuration; deployments provide the real values to the final stage.
+ENV DATABASE_URL=postgresql://crawlseo:crawlseo@localhost:5432/crawlseo
+ENV GOOGLE_CLIENT_ID=docker-build-placeholder
+ENV GOOGLE_CLIENT_SECRET=docker-build-placeholder
+ENV NEXTAUTH_SECRET=docker-build-placeholder
 RUN npx prisma generate
 RUN npm run build
 
 FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+COPY package-lock.json ./
+# Keep the migration CLI in the image instead of downloading it through npx at
+# container startup. Reading the version from the lockfile keeps it aligned with
+# the generated Prisma client.
+RUN npm install --global "prisma@$(node -p \"require('./package-lock.json').packages['node_modules/prisma'].version\")" \
+    && npm cache clean --force
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
@@ -25,4 +38,4 @@ COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
-CMD ["sh", "-c", "npx prisma migrate deploy && node server.js"]
+CMD ["sh", "-c", "prisma migrate deploy && node server.js"]

--- a/README.md
+++ b/README.md
@@ -168,10 +168,29 @@ git clone https://github.com/crawlseo/crawlseo.git
 cd crawlseo
 cp .env.example .env
 # Edit .env with your credentials
-docker compose up --build
+docker compose pull
+docker compose up -d
 ```
 
-The full stack (PostgreSQL + Next.js) starts in ~2 minutes. Migrations run automatically.
+Compose pulls the prebuilt `ghcr.io/crawlseo/crawlseo:latest` image, so deployment
+credentials are only needed at runtime. Images support `linux/amd64` and
+`linux/arm64`, and database migrations run automatically when the container
+starts.
+
+Version tags are also published as immutable image tags (for example, `1.2.3`)
+and minor-version tags (for example, `1.2`). To use a pinned release or an image
+from a fork, set `CRAWLSEO_IMAGE` in `.env`:
+
+```bash
+CRAWLSEO_IMAGE=ghcr.io/crawlseo/crawlseo:1.2.3
+```
+
+To build locally instead, build the same image name before starting Compose:
+
+```bash
+docker build -t crawlseo:local .
+CRAWLSEO_IMAGE=crawlseo:local docker compose up -d
+```
 
 ### Manual
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,23 @@
 services:
   app:
-    build: .
+    image: ${CRAWLSEO_IMAGE:-ghcr.io/crawlseo/crawlseo:latest}
     restart: always
     ports:
       - "3000:3000"
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     depends_on:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:3000/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Closes #3

## Problem

Compose builds the image locally by default, which breaks on platforms like Coolify that don't forward env vars into the build step, since the Next.js build needs values like DATABASE_URL and the Google OAuth credentials to compile.

## Changes

- Add a GitHub Actions workflow (`.github/workflows/docker-publish.yml`) that builds amd64/arm64 images and pushes them to ghcr.io on push to main, on version tags, and on manual dispatch. PRs still build the image to validate it, but don't push.
- `docker-compose.yml` now pulls `ghcr.io/crawlseo/crawlseo:latest` instead of building locally. Set `CRAWLSEO_IMAGE` in `.env` to pin a release tag or point at an image built from a fork.
- `Dockerfile` build stage now sets non-secret placeholder values for DATABASE_URL, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and NEXTAUTH_SECRET so the image can be built without real runtime config. Also installs the Prisma CLI globally at build time instead of resolving it through npx at container start.
- README quick start updated to `docker compose pull && docker compose up -d`, with a section on pinning versions or building locally.

## Test plan

- [ ] `docker compose pull && docker compose up -d` starts the stack against a published image
- [ ] `docker build -t crawlseo:local .` still works for local builds
- [ ] Workflow runs on a PR and builds successfully without pushing