### PR TITLE
fix: install curl in runner image so the Docker healthcheck can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN npm run build
 FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+RUN apk add --no-cache curl
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## What changed

Adds `RUN apk add --no-cache curl` to the runner stage of the Dockerfile.

## Why

`docker-compose.yml`'s healthcheck runs:
```
curl -f http://localhost:3000/api/health
```

But the `node:20-alpine` runner stage never installs curl. Every healthcheck attempt fails with:
```
OCI runtime exec failed: exec failed: unable to start container process: exec: "curl": executable file not found in $PATH
```

This means the container is marked `unhealthy` permanently, regardless of whether the app itself is actually serving traffic correctly - the healthcheck is unsatisfiable by construction, not reflecting real app health.

## Verification

- Built the image on this branch and confirmed curl is present: `docker run --rm --entrypoint sh crawlseo-app:test-curl -c "which curl"` → `/usr/bin/curl`
- `npm run build` passes
- Confirmed via `docker inspect --format='{{json .State.Health}}'` on a running deployment that the failures were a consistent, identical exec error (missing binary), not intermittent app errors - `/api/health` itself only does a trivial `SELECT 1` against Postgres and the DB was healthy the whole time.

This is one of two small, independent fixes found while debugging a stuck local deployment - the other (Next standalone server binding, since Docker auto-sets `$HOSTNAME` to the container ID and Next's server picks that up as its bind address) is in a separate PR to keep each focused per the contributing guide.