### PR TITLE
Add per-user Google PageSpeed API key support

### DIFF
--- a/app/(dashboard)/sites/[siteId]/settings/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/settings/page.tsx
@@ -41,6 +41,7 @@ export default async function SettingsPage({ params }: Props) {
   });
   const apiKeyStatus: Record<string, { connected: boolean; updatedAt?: string }> = {
     dataforseo: { connected: false },
+    google_pagespeed: { connected: false },
   };
   for (const key of apiKeys) {
     apiKeyStatus[key.provider] = {

--- a/app/api/sites/[siteId]/vitals/route.ts
+++ b/app/api/sites/[siteId]/vitals/route.ts
@@ -23,6 +23,9 @@ export async function POST(
       return Response.json({ error: "Not found" }, { status: 404 });
     }
     const result = await syncVitalsForSite(session.user.id, siteId, 5);
+    if (result.error) {
+      return Response.json(result, { status: 502 });
+    }
     return Response.json(result);
   } catch (error) {
     console.error(error);

--- a/app/api/user/api-keys/route.ts
+++ b/app/api/user/api-keys/route.ts
@@ -2,6 +2,13 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { encrypt } from "@/lib/encryption";
 
+const SUPPORTED_PROVIDERS = ["dataforseo", "google_pagespeed"] as const;
+type Provider = (typeof SUPPORTED_PROVIDERS)[number];
+
+function isSupportedProvider(value: unknown): value is Provider {
+  return typeof value === "string" && SUPPORTED_PROVIDERS.includes(value as Provider);
+}
+
 export async function GET() {
   try {
     const session = await auth();
@@ -16,6 +23,7 @@ export async function GET() {
 
     const providers: Record<string, { connected: boolean; updatedAt?: string }> = {
       dataforseo: { connected: false },
+      google_pagespeed: { connected: false },
     };
 
     for (const key of keys) {
@@ -43,17 +51,36 @@ export async function POST(req: Request) {
       provider?: string;
       login?: string;
       password?: string;
+      apiKey?: string;
     };
 
-    if (!body.provider || !body.login || !body.password) {
-      return Response.json(
-        { error: "Missing required fields: provider, login, password" },
-        { status: 400 }
-      );
+    if (!isSupportedProvider(body.provider)) {
+      return Response.json({ error: "Unsupported provider" }, { status: 400 });
     }
 
-    if (body.provider !== "dataforseo") {
-      return Response.json({ error: "Unsupported provider" }, { status: 400 });
+    // dataforseo: login + password (Basic Auth style credentials).
+    // google_pagespeed: a single key string - no login concept.
+    let encryptedLogin: string | null;
+    let encryptedPassword: string;
+
+    if (body.provider === "dataforseo") {
+      if (!body.login || !body.password) {
+        return Response.json(
+          { error: "Missing required fields: login, password" },
+          { status: 400 }
+        );
+      }
+      encryptedLogin = encrypt(body.login);
+      encryptedPassword = encrypt(body.password);
+    } else {
+      if (!body.apiKey) {
+        return Response.json(
+          { error: "Missing required field: apiKey" },
+          { status: 400 }
+        );
+      }
+      encryptedLogin = null;
+      encryptedPassword = encrypt(body.apiKey);
     }
 
     const saved = await db.apiKey.upsert({
@@ -66,12 +93,12 @@ export async function POST(req: Request) {
       create: {
         userId: session.user.id,
         provider: body.provider,
-        encryptedLogin: encrypt(body.login),
-        encryptedPassword: encrypt(body.password),
+        encryptedLogin,
+        encryptedPassword,
       },
       update: {
-        encryptedLogin: encrypt(body.login),
-        encryptedPassword: encrypt(body.password),
+        encryptedLogin,
+        encryptedPassword,
       },
     });
 
@@ -93,8 +120,8 @@ export async function DELETE(req: Request) {
     }
 
     const body = (await req.json()) as { provider?: string };
-    if (!body.provider) {
-      return Response.json({ error: "Missing provider" }, { status: 400 });
+    if (!isSupportedProvider(body.provider)) {
+      return Response.json({ error: "Unsupported provider" }, { status: 400 });
     }
 
     await db.apiKey.delete({

--- a/components/settings/api-keys-section.tsx
+++ b/components/settings/api-keys-section.tsx
@@ -19,7 +19,13 @@ export function ApiKeysSection({
   const [testResult, setTestResult] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [pagespeedKey, setPagespeedKey] = useState("");
+  const [pagespeedSaving, setPagespeedSaving] = useState(false);
+  const [pagespeedDeleting, setPagespeedDeleting] = useState(false);
+  const [pagespeedError, setPagespeedError] = useState<string | null>(null);
+
   const isConnected = status.dataforseo?.connected ?? false;
+  const isPagespeedConnected = status.google_pagespeed?.connected ?? false;
 
   async function handleTest() {
     if (!login || !password) return;
@@ -96,6 +102,59 @@ export function ApiKeysSection({
       setError("Delete failed");
     } finally {
       setDeleting(false);
+    }
+  }
+
+  async function handlePagespeedSave() {
+    if (!pagespeedKey) return;
+    setPagespeedSaving(true);
+    setPagespeedError(null);
+
+    try {
+      const res = await fetch("/api/user/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "google_pagespeed", apiKey: pagespeedKey }),
+      });
+
+      if (res.ok) {
+        setStatus((prev) => ({
+          ...prev,
+          google_pagespeed: { connected: true, updatedAt: new Date().toISOString() },
+        }));
+        setPagespeedKey("");
+      } else {
+        const data = await res.json();
+        setPagespeedError(data.error || "Failed to save");
+      }
+    } catch {
+      setPagespeedError("Save failed");
+    } finally {
+      setPagespeedSaving(false);
+    }
+  }
+
+  async function handlePagespeedDelete() {
+    setPagespeedDeleting(true);
+    setPagespeedError(null);
+
+    try {
+      const res = await fetch("/api/user/api-keys", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "google_pagespeed" }),
+      });
+
+      if (res.ok) {
+        setStatus((prev) => ({
+          ...prev,
+          google_pagespeed: { connected: false },
+        }));
+      }
+    } catch {
+      setPagespeedError("Delete failed");
+    } finally {
+      setPagespeedDeleting(false);
     }
   }
 
@@ -213,6 +272,87 @@ export function ApiKeysSection({
                 className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
               >
                 {saving ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Save className="size-3" />
+                )}
+                Save Key
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 rounded-lg border border-border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h4 className="font-medium text-foreground">Google PageSpeed Insights</h4>
+            <p className="text-xs text-muted-foreground">
+              Core Web Vitals and Lighthouse lab data for your top pages
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {isPagespeedConnected ? (
+              <span className="flex items-center gap-1.5 rounded-full bg-signal/10 px-2.5 py-1 text-xs font-medium text-signal">
+                <CheckCircle2 className="size-3.5" />
+                Connected
+              </span>
+            ) : (
+              <span className="flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                <XCircle className="size-3.5" />
+                Not configured
+              </span>
+            )}
+          </div>
+        </div>
+
+        {isPagespeedConnected ? (
+          <div className="mt-4 flex items-center justify-between">
+            <p className="text-xs text-muted-foreground">
+              Last updated:{" "}
+              {status.google_pagespeed.updatedAt
+                ? new Date(status.google_pagespeed.updatedAt).toLocaleDateString()
+                : "—"}
+            </p>
+            <button
+              type="button"
+              onClick={handlePagespeedDelete}
+              disabled={pagespeedDeleting}
+              className="flex items-center gap-1.5 rounded-lg border border-danger/30 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/10 disabled:opacity-50"
+            >
+              {pagespeedDeleting ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Trash2 className="size-3" />
+              )}
+              Remove
+            </button>
+          </div>
+        ) : (
+          <div className="mt-4 space-y-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                API Key
+              </label>
+              <input
+                type="password"
+                value={pagespeedKey}
+                onChange={(e) => setPagespeedKey(e.target.value)}
+                placeholder="AIza..."
+                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+
+            {pagespeedError && <p className="text-xs text-danger">{pagespeedError}</p>}
+
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handlePagespeedSave}
+                disabled={!pagespeedKey || pagespeedSaving}
+                className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+              >
+                {pagespeedSaving ? (
                   <Loader2 className="size-3 animate-spin" />
                 ) : (
                   <Save className="size-3" />

--- a/lib/dataforseo/client.ts
+++ b/lib/dataforseo/client.ts
@@ -104,7 +104,7 @@ async function getCredentials(userId: string): Promise<{ login: string; password
   const apiKey = await db.apiKey.findUnique({
     where: { userId_provider: { userId, provider: "dataforseo" } },
   });
-  if (!apiKey) return null;
+  if (!apiKey || !apiKey.encryptedLogin) return null;
 
   return {
     login: decrypt(apiKey.encryptedLogin),

--- a/lib/google/pagespeed-client.ts
+++ b/lib/google/pagespeed-client.ts
@@ -1,4 +1,17 @@
+import { db } from "@/lib/db";
+import { decrypt } from "@/lib/encryption";
+
 const PAGESPEED_API_BASE = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed";
+
+async function resolveApiKey(userId?: string): Promise<string | undefined> {
+  if (userId) {
+    const stored = await db.apiKey.findUnique({
+      where: { userId_provider: { userId, provider: "google_pagespeed" } },
+    });
+    if (stored) return decrypt(stored.encryptedPassword);
+  }
+  return process.env.GOOGLE_PAGESPEED_KEY;
+}
 
 export interface CoreWebVitals {
   lcp?: number; // Largest Contentful Paint (seconds)
@@ -35,15 +48,17 @@ function msToSeconds(ms?: number): number | undefined {
  */
 export async function fetchPageSpeed(
   url: string,
-  strategy: "MOBILE" | "DESKTOP" = "MOBILE"
+  strategy: "MOBILE" | "DESKTOP" = "MOBILE",
+  userId?: string
 ): Promise<PageSpeedResult> {
   const params = new URLSearchParams({
     url,
     category: "PERFORMANCE",
     strategy,
   });
-  if (process.env.GOOGLE_PAGESPEED_KEY) {
-    params.set("key", process.env.GOOGLE_PAGESPEED_KEY);
+  const apiKey = await resolveApiKey(userId);
+  if (apiKey) {
+    params.set("key", apiKey);
   }
 
   const response = await fetch(`${PAGESPEED_API_BASE}?${params}`, {

--- a/lib/workers/vitals-sync.ts
+++ b/lib/workers/vitals-sync.ts
@@ -29,12 +29,15 @@ export async function syncVitalsForSite(
   );
 
   let inserted = 0;
-  const results = [];
+  const results: Array<
+    | { url: string; device: "MOBILE"; perfScore: number; lcp?: number; cls?: number }
+    | { url: string; error: string }
+  > = [];
 
   for (const url of normalized.slice(0, limit)) {
     try {
       // Prefer mobile (ranking signal)
-      const mobile = await fetchPageSpeed(url, "MOBILE");
+      const mobile = await fetchPageSpeed(url, "MOBILE", userId);
       await db.vitalsReport.create({
         data: {
           siteId,
@@ -57,12 +60,27 @@ export async function syncVitalsForSite(
         cls: mobile.vitals.cls,
       });
     } catch (err) {
-      results.push({
-        url,
-        error: err instanceof Error ? err.message : "Failed",
-      });
+      const message = err instanceof Error ? err.message : "Failed";
+      results.push({ url, error: message });
+
+      // A quota error means every remaining page will fail identically -
+      // stop burning requests against an already-exhausted daily quota
+      // instead of retrying 4 more times for the same result.
+      if (message.includes("429") || /quota exceeded/i.test(message)) {
+        break;
+      }
     }
   }
 
-  return { inserted, results };
+  // If nothing was inserted and every attempt failed, the caller (the API
+  // route) needs a real error to surface - without this, "0 succeeded, all
+  // failed" and "0 succeeded, nothing to check" look identical to the UI,
+  // which previously showed "Saved 0 PageSpeed reports" as if it worked.
+  const failures = results.filter(
+    (r): r is { url: string; error: string } => "error" in r
+  );
+  const error =
+    inserted === 0 && failures.length > 0 ? failures[0].error : undefined;
+
+  return { inserted, results, error };
 }

--- a/prisma/migrations/20260805000000_apikey_login_optional/migration.sql
+++ b/prisma/migrations/20260805000000_apikey_login_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ApiKey" ALTER COLUMN "encryptedLogin" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,9 +67,9 @@ model VerificationToken {
 model ApiKey {
   id                String   @id @default(cuid())
   userId            String
-  provider          String   // "dataforseo"
-  encryptedLogin    String
-  encryptedPassword String
+  provider          String   // "dataforseo" (login+password) | "google_pagespeed" (single key)
+  encryptedLogin    String?  // null for single-key providers like google_pagespeed
+  encryptedPassword String   // holds the API key itself for single-key providers
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- Vitals sync fails once the shared `GOOGLE_PAGESPEED_KEY` env var hits its daily quota, with no way for a user to supply their own key.
- Adds a `google_pagespeed` provider to the existing BYOK api-keys flow (single key field, no login) alongside DataForSEO's login+password, with a new card in Settings.
- `fetchPageSpeed()` now prefers a user's stored key, falling back to the shared env var.
- Vitals sync now surfaces a real 502 error when every page fails (instead of silently reporting "0 inserted" as a success), and stops retrying once it hits a quota error instead of burning the rest of the batch on requests that will fail identically.

## Test plan
- [x] `npm run build` (typecheck) passes
- [x] Rebuilt and redeployed the Docker container with the change
- [x] Live end-to-end test against a running instance: saved a real Google PageSpeed key via `POST /api/user/api-keys`, confirmed it shows connected via `GET /api/user/api-keys`, then triggered `POST /api/sites/{siteId}/vitals` — returned 200 with 5/5 pages inserted with real Lighthouse data, confirming the stored per-user key was picked up and used
- [x] Verified the DataForSEO login+password round trip still works after making `encryptedLogin` nullable in the schema (existing dataforseo connections aren't disturbed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)