### PR TITLE
feat: consistent sorting and search across all metric tables

### DIFF
--- a/app/(dashboard)/sites/[siteId]/crawl/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/crawl/page.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
 import { CrawlButton } from "@/components/sites/action-buttons";
 import { CrawlStatusPoller } from "@/components/sites/crawl-status-poller";
+import { CrawledPagesTable } from "@/components/sites/crawled-pages-table";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -117,75 +118,27 @@ export default async function CrawlPage({ params }: Props) {
 
           {/* Crawled pages table (from AuditPage model) */}
           {auditPages.length > 0 && (
-            <div className="panel overflow-hidden">
-              <div className="border-b border-border/60 px-5 py-4">
+            <div>
+              <div className="px-1 pb-3">
                 <h3 className="font-heading text-lg font-semibold">Crawled pages</h3>
                 <p className="text-sm text-muted-foreground">
                   {auditPages.length} pages stored with full metadata
                 </p>
               </div>
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[800px] text-sm">
-                  <thead>
-                    <tr className="border-b border-border/50 bg-muted/20 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-                      <th className="px-4 py-3 text-left">URL</th>
-                      <th className="px-4 py-3 text-right">Status</th>
-                      <th className="px-4 py-3 text-right">Score</th>
-                      <th className="px-4 py-3 text-right">Words</th>
-                      <th className="px-4 py-3 text-right">H1s</th>
-                      <th className="px-4 py-3 text-right">Images</th>
-                      <th className="px-4 py-3 text-right">Int. links</th>
-                      <th className="px-4 py-3 text-right">Time</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border/40">
-                    {auditPages.slice(0, 100).map((p) => (
-                      <tr key={p.id} className="hover:bg-muted/20">
-                        <td className="max-w-md truncate px-4 py-2.5 font-medium" title={p.url}>
-                          {p.url}
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data">
-                          <span className={cn(
-                            p.statusCode >= 400 ? "text-danger" :
-                            p.statusCode >= 300 ? "text-warning" : "text-signal"
-                          )}>
-                            {p.statusCode}
-                          </span>
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data">
-                          <span className={cn(
-                            p.contentScore >= 70 ? "text-signal" :
-                            p.contentScore >= 50 ? "text-warning" : "text-danger"
-                          )}>
-                            {p.contentScore}
-                          </span>
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
-                          {p.wordCount}
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
-                          {p.h1Count}
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
-                          {p.imagesMissingAlt > 0 ? (
-                            <span className="text-warning">
-                              {p.imagesMissingAlt}/{p.imageCount}
-                            </span>
-                          ) : (
-                            p.imageCount
-                          )}
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
-                          {p.internalLinks}
-                        </td>
-                        <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
-                          {p.responseTimeMs}ms
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <CrawledPagesTable
+                rows={auditPages.slice(0, 100).map((p) => ({
+                  id: p.id,
+                  url: p.url,
+                  statusCode: p.statusCode,
+                  contentScore: p.contentScore,
+                  wordCount: p.wordCount,
+                  h1Count: p.h1Count,
+                  imageCount: p.imageCount,
+                  imagesMissingAlt: p.imagesMissingAlt,
+                  internalLinks: p.internalLinks,
+                  responseTimeMs: p.responseTimeMs,
+                }))}
+              />
             </div>
           )}
 

--- a/app/(dashboard)/sites/[siteId]/pages/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/pages/page.tsx
@@ -7,12 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { SyncButton } from "@/components/sites/sync-button";
 import { CsvExportButton } from "@/components/ui/csv-export-button";
 import { DataLagBadge } from "@/components/ui/data-lag-badge";
-import {
-  PositionBadge,
-  MetricTable,
-  CtrCell,
-  NumCell,
-} from "@/components/ui/data-table";
+import { PagesTable } from "@/components/sites/pages-table";
 
 interface PagesPageProps {
   params: Promise<{ siteId: string }>;
@@ -55,52 +50,16 @@ export default async function PagesPage({ params }: PagesPageProps) {
           description="Sync GSC to pull page-level clicks, impressions, and positions."
         />
       ) : (
-        <MetricTable
-          headers={[
-            { label: "URL" },
-            { label: "Position", align: "right" },
-            { label: "Clicks", align: "right" },
-            { label: "Impressions", align: "right" },
-            { label: "CTR", align: "right" },
-          ]}
-          footer={`Showing ${pages.length} pages · sorted by clicks`}
-        >
-          {pages.map((page) => {
-            const href = page.url.startsWith("http")
-              ? page.url
-              : `https://${site.domain}${page.url.startsWith("/") ? "" : "/"}${page.url}`;
-
-            return (
-              <tr
-                key={page.url}
-                className="transition-colors hover:bg-muted/25"
-              >
-                <td className="max-w-xl px-4 py-3">
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="break-all font-medium text-signal hover:underline"
-                  >
-                    {page.url}
-                  </a>
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <PositionBadge position={page.position} />
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <NumCell value={page.clicks} />
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <NumCell value={page.impressions} />
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <CtrCell ctr={page.ctr} />
-                </td>
-              </tr>
-            );
-          })}
-        </MetricTable>
+        <PagesTable
+          domain={site.domain}
+          rows={pages.map((p) => ({
+            url: p.url,
+            position: p.position,
+            clicks: p.clicks,
+            impressions: p.impressions,
+            ctr: p.ctr,
+          }))}
+        />
       )}
     </div>
   );

--- a/app/(dashboard)/sites/[siteId]/saved-keywords/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/saved-keywords/page.tsx
@@ -3,8 +3,8 @@ import { db } from "@/lib/db";
 import { redirect } from "next/navigation";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
-import { SaveKeywordForm, DeleteKeywordButton } from "@/components/sites/saved-keyword-actions";
-import { PositionBadge, NumCell, CtrCell } from "@/components/ui/data-table";
+import { SaveKeywordForm } from "@/components/sites/saved-keyword-actions";
+import { SavedKeywordsTable } from "@/components/sites/saved-keywords-table";
 import { getDateRange } from "@/lib/date-utils";
 
 interface Props {
@@ -69,70 +69,21 @@ export default async function SavedKeywordsPage({ params }: Props) {
           description="Save keywords you want to track closely. Use the form above to add your first keyword."
         />
       ) : (
-        <div className="panel overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[640px] text-sm">
-              <thead>
-                <tr className="border-b border-border/70 bg-muted/30">
-                  <th className="px-4 py-3 text-left text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Keyword
-                  </th>
-                  <th className="px-4 py-3 text-left text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Notes
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Position
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Clicks
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Impr.
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    CTR
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {saved.map((kw) => {
-                  const data = dataMap.get(kw.query);
-                  return (
-                    <tr key={kw.id} className="transition-colors hover:bg-muted/25">
-                      <td className="px-4 py-3 font-medium text-foreground">
-                        {kw.query}
-                      </td>
-                      <td className="max-w-xs truncate px-4 py-3 text-muted-foreground">
-                        {kw.notes || "—"}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {data ? <PositionBadge position={data.position} /> : "—"}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {data ? <NumCell value={data.clicks} /> : "—"}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {data ? <NumCell value={data.impressions} /> : "—"}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {data ? <CtrCell ctr={data.ctr} /> : "—"}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <DeleteKeywordButton siteId={siteId} query={kw.query} />
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-          <div className="border-t border-border/60 bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
-            {saved.length} saved keywords · last 28 days aggregated
-          </div>
-        </div>
+        <SavedKeywordsTable
+          siteId={siteId}
+          rows={saved.map((kw) => {
+            const data = dataMap.get(kw.query);
+            return {
+              id: kw.id,
+              query: kw.query,
+              notes: kw.notes,
+              position: data?.position ?? null,
+              clicks: data?.clicks ?? null,
+              impressions: data?.impressions ?? null,
+              ctr: data?.ctr ?? null,
+            };
+          })}
+        />
       )}
     </div>
   );

--- a/app/(dashboard)/sites/[siteId]/vitals/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/vitals/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
 import { VitalsButton, IndexCheckButton } from "@/components/sites/action-buttons";
-import { cn } from "@/lib/utils";
+import { VitalsTable } from "@/components/sites/vitals-table";
 
 interface Props {
   params: Promise<{ siteId: string }>;
@@ -42,56 +42,18 @@ export default async function VitalsPage({ params }: Props) {
           description="Run a check on your top landing pages (mobile Lighthouse)."
         />
       ) : (
-        <div className="panel overflow-x-auto">
-          <table className="w-full min-w-[720px] text-sm">
-            <thead>
-              <tr className="border-b border-border/50 bg-muted/20 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-                <th className="px-4 py-3 text-left">URL</th>
-                <th className="px-4 py-3 text-right">Score</th>
-                <th className="px-4 py-3 text-right">LCP</th>
-                <th className="px-4 py-3 text-right">CLS</th>
-                <th className="px-4 py-3 text-right">INP</th>
-                <th className="px-4 py-3 text-right">TTFB</th>
-                <th className="px-4 py-3 text-left">When</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/40">
-              {reports.map((r) => (
-                <tr key={r.id} className="hover:bg-muted/20">
-                  <td className="max-w-xs truncate px-4 py-2.5 font-medium">{r.url}</td>
-                  <td className="px-4 py-2.5 text-right font-data">
-                    <span
-                      className={cn(
-                        (r.perfScore ?? 0) >= 90
-                          ? "text-signal"
-                          : (r.perfScore ?? 0) >= 50
-                            ? "text-warning"
-                            : "text-danger"
-                      )}
-                    >
-                      {r.perfScore ?? "—"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-2.5 text-right font-data">
-                    {r.lcp != null ? `${r.lcp.toFixed(2)}s` : "—"}
-                  </td>
-                  <td className="px-4 py-2.5 text-right font-data">
-                    {r.cls != null ? r.cls.toFixed(3) : "—"}
-                  </td>
-                  <td className="px-4 py-2.5 text-right font-data">
-                    {r.inp != null ? `${Math.round(r.inp)}ms` : "—"}
-                  </td>
-                  <td className="px-4 py-2.5 text-right font-data">
-                    {r.ttfb != null ? `${r.ttfb.toFixed(2)}s` : "—"}
-                  </td>
-                  <td className="px-4 py-2.5 text-xs text-muted-foreground">
-                    {new Date(r.date).toLocaleString()}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <VitalsTable
+          rows={reports.map((r) => ({
+            id: r.id,
+            url: r.url,
+            perfScore: r.perfScore,
+            lcp: r.lcp,
+            cls: r.cls,
+            inp: r.inp,
+            ttfb: r.ttfb,
+            date: r.date.toISOString(),
+          }))}
+        />
       )}
 
       <div className="panel mt-6 p-5">

--- a/components/sites/crawled-pages-table.tsx
+++ b/components/sites/crawled-pages-table.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useDeferredValue, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  MetricTable,
+  useTableSort,
+  sortRows,
+  sortLabel,
+  SearchField,
+  type MetricHeader,
+} from "@/components/ui/data-table";
+
+const HEADERS: MetricHeader[] = [
+  { label: "URL", sortKey: "url", defaultDir: "asc" },
+  { label: "Status", align: "right", sortKey: "statusCode" },
+  { label: "Score", align: "right", sortKey: "contentScore" },
+  { label: "Words", align: "right", sortKey: "wordCount" },
+  { label: "H1s", align: "right", sortKey: "h1Count" },
+  { label: "Images", align: "right", sortKey: "imagesMissingAlt" },
+  { label: "Int. links", align: "right", sortKey: "internalLinks" },
+  { label: "Time", align: "right", sortKey: "responseTimeMs" },
+];
+
+export interface CrawledPageRowData {
+  id: string;
+  url: string;
+  statusCode: number;
+  contentScore: number;
+  wordCount: number;
+  h1Count: number;
+  imageCount: number;
+  imagesMissingAlt: number;
+  internalLinks: number;
+  responseTimeMs: number;
+}
+
+export function CrawledPagesTable({ rows }: { rows: CrawledPageRowData[] }) {
+  const [search, setSearch] = useState("");
+  const { sort, toggle } = useTableSort({ key: "contentScore", dir: "desc" });
+
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+  const filtered = useMemo(() => {
+    const out = deferredSearch
+      ? rows.filter((r) => r.url.toLowerCase().includes(deferredSearch))
+      : rows;
+    return sortRows(out, sort);
+  }, [rows, deferredSearch, sort]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-3">
+        <SearchField value={search} onChange={setSearch} placeholder="Filter by URL..." />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="panel px-4 py-10 text-center">
+          <p className="font-medium text-foreground">No pages match</p>
+          <p className="mt-1 text-sm text-muted-foreground">Loosen the search.</p>
+        </div>
+      ) : (
+        <MetricTable
+          sort={sort}
+          onSort={toggle}
+          headers={HEADERS}
+          footer={`Showing ${filtered.length} of ${rows.length} pages · sorted by ${sortLabel(HEADERS, sort)}`}
+        >
+          {filtered.map((p) => (
+            <tr key={p.id} className="hover:bg-muted/20">
+              <td className="max-w-md truncate px-4 py-2.5 font-medium" title={p.url}>
+                {p.url}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                <span
+                  className={cn(
+                    p.statusCode >= 400
+                      ? "text-danger"
+                      : p.statusCode >= 300
+                        ? "text-warning"
+                        : "text-signal"
+                  )}
+                >
+                  {p.statusCode}
+                </span>
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                <span
+                  className={cn(
+                    p.contentScore >= 70
+                      ? "text-signal"
+                      : p.contentScore >= 50
+                        ? "text-warning"
+                        : "text-danger"
+                  )}
+                >
+                  {p.contentScore}
+                </span>
+              </td>
+              <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
+                {p.wordCount}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
+                {p.h1Count}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
+                {p.imagesMissingAlt > 0 ? (
+                  <span className="text-warning">
+                    {p.imagesMissingAlt}/{p.imageCount}
+                  </span>
+                ) : (
+                  p.imageCount
+                )}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
+                {p.internalLinks}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data text-muted-foreground">
+                {p.responseTimeMs}ms
+              </td>
+            </tr>
+          ))}
+        </MetricTable>
+      )}
+    </div>
+  );
+}

--- a/components/sites/keywords-table.tsx
+++ b/components/sites/keywords-table.tsx
@@ -7,18 +7,20 @@ import {
   MetricTable,
   CtrCell,
   NumCell,
+  useTableSort,
+  sortRows,
+  sortLabel,
+  SearchField,
+  filterInputClass,
+  matchesPosition,
+  parseMin,
+  POSITION_OPTIONS,
+  type MetricHeader,
+  type PositionFilter,
+  type SortDir,
 } from "@/components/ui/data-table";
 
-type PositionFilter = "all" | "top3" | "top10" | "11-20" | "20+";
-type SortKey = "clicks" | "impressions" | "position" | "ctr";
-
-const POSITION_OPTIONS: { value: PositionFilter; label: string }[] = [
-  { value: "all", label: "All positions" },
-  { value: "top3", label: "Top 3" },
-  { value: "top10", label: "Top 10" },
-  { value: "11-20", label: "11–20" },
-  { value: "20+", label: "20+" },
-];
+type SortKey = "query" | "clicks" | "impressions" | "position" | "ctr";
 
 const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: "clicks", label: "Clicks" },
@@ -27,26 +29,28 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: "ctr", label: "CTR" },
 ];
 
-function matchesPosition(position: number, filter: PositionFilter): boolean {
-  if (filter === "all") return true;
-  if (filter === "top3") return position > 0 && position <= 3;
-  if (filter === "top10") return position > 0 && position <= 10;
-  if (filter === "11-20") return position > 10 && position <= 20;
-  return position > 20;
-}
+const HEADERS: MetricHeader[] = [
+  { label: "Query", sortKey: "query", defaultDir: "asc" },
+  { label: "Position", align: "right", sortKey: "position", defaultDir: "asc" },
+  { label: "Clicks", align: "right", sortKey: "clicks" },
+  { label: "Impressions", align: "right", sortKey: "impressions" },
+  { label: "CTR", align: "right", sortKey: "ctr" },
+];
 
-function parseMin(value: string): number | null {
-  if (value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
-}
+const DEFAULT_DIRS: Record<SortKey, SortDir> = {
+  query: "asc",
+  position: "asc",
+  clicks: "desc",
+  impressions: "desc",
+  ctr: "desc",
+};
 
 export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
   const [search, setSearch] = useState("");
   const [position, setPosition] = useState<PositionFilter>("all");
   const [minClicks, setMinClicks] = useState("");
   const [minImpressions, setMinImpressions] = useState("");
-  const [sortBy, setSortBy] = useState<SortKey>("clicks");
+  const { sort, setSort, toggle } = useTableSort({ key: "clicks", dir: "desc" });
 
   const deferredSearch = useDeferredValue(search.trim().toLowerCase());
   const minClicksNum = parseMin(minClicks);
@@ -65,27 +69,14 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
       return true;
     });
 
-    rows.sort((a, b) => {
-      if (sortBy === "position") {
-        return a.position - b.position || b.impressions - a.impressions;
-      }
-      if (sortBy === "impressions") {
-        return b.impressions - a.impressions || b.clicks - a.clicks;
-      }
-      if (sortBy === "ctr") {
-        return b.ctr - a.ctr || b.impressions - a.impressions;
-      }
-      return b.clicks - a.clicks || b.impressions - a.impressions;
-    });
-
-    return rows;
+    return sortRows(rows, sort);
   }, [
     keywords,
     deferredSearch,
     position,
     minClicksNum,
     minImpressionsNum,
-    sortBy,
+    sort,
   ]);
 
   const hasActiveFilters =
@@ -93,34 +84,26 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
     position !== "all" ||
     minClicks.trim() !== "" ||
     minImpressions.trim() !== "" ||
-    sortBy !== "clicks";
+    sort.key !== "clicks" ||
+    sort.dir !== "desc";
 
   function clearFilters() {
     setSearch("");
     setPosition("all");
     setMinClicks("");
     setMinImpressions("");
-    setSortBy("clicks");
+    setSort({ key: "clicks", dir: "desc" });
   }
 
-  const inputClass =
-    "h-9 rounded-lg border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary";
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-end gap-2">
-        <label className="flex min-w-[180px] flex-1 flex-col gap-1">
-          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-            Search
-          </span>
-          <input
-            type="search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Filter by query…"
-            className={inputClass}
-          />
-        </label>
+      <div className="flex flex-wrap items-end gap-3">
+        <SearchField
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter by query..."
+        />
 
         <label className="flex flex-col gap-1">
           <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
@@ -129,7 +112,7 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
           <select
             value={position}
             onChange={(e) => setPosition(e.target.value as PositionFilter)}
-            className={`${inputClass} pr-8`}
+            className={`${filterInputClass} pr-8`}
           >
             {POSITION_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -139,33 +122,31 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
           </select>
         </label>
 
-        <label className="flex w-28 flex-col gap-1">
+        <label className="flex flex-col gap-1">
           <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
             Min clicks
           </span>
           <input
             type="number"
             min={0}
-            inputMode="numeric"
             value={minClicks}
             onChange={(e) => setMinClicks(e.target.value)}
             placeholder="0"
-            className={inputClass}
+            className={`${filterInputClass} w-24`}
           />
         </label>
 
-        <label className="flex w-32 flex-col gap-1">
+        <label className="flex flex-col gap-1">
           <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
             Min impressions
           </span>
           <input
             type="number"
             min={0}
-            inputMode="numeric"
             value={minImpressions}
             onChange={(e) => setMinImpressions(e.target.value)}
             placeholder="0"
-            className={inputClass}
+            className={`${filterInputClass} w-24`}
           />
         </label>
 
@@ -174,9 +155,12 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
             Sort by
           </span>
           <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as SortKey)}
-            className={`${inputClass} pr-8`}
+            value={sort.key}
+            onChange={(e) => {
+              const key = e.target.value as SortKey;
+              setSort({ key, dir: DEFAULT_DIRS[key] });
+            }}
+            className={`${filterInputClass} pr-8`}
           >
             {SORT_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -190,7 +174,7 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
           <button
             type="button"
             onClick={clearFilters}
-            className="h-9 rounded-lg border border-border px-3 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            className="h-9 rounded-lg border border-border px-3 text-sm text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
           >
             Clear
           </button>
@@ -206,14 +190,10 @@ export function KeywordsTable({ keywords }: { keywords: KeywordRow[] }) {
         </div>
       ) : (
         <MetricTable
-          headers={[
-            { label: "Query" },
-            { label: "Position", align: "right" },
-            { label: "Clicks", align: "right" },
-            { label: "Impressions", align: "right" },
-            { label: "CTR", align: "right" },
-          ]}
-          footer={`Showing ${filtered.length} of ${keywords.length} keywords · sorted by ${sortBy}`}
+          sort={sort}
+          onSort={toggle}
+          headers={HEADERS}
+          footer={`Showing ${filtered.length} of ${keywords.length} keywords · sorted by ${sortLabel(HEADERS, sort)}`}
         >
           {filtered.map((keyword) => (
             <tr

--- a/components/sites/pages-table.tsx
+++ b/components/sites/pages-table.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useDeferredValue, useMemo, useState } from "react";
+import {
+  PositionBadge,
+  MetricTable,
+  CtrCell,
+  NumCell,
+  useTableSort,
+  sortRows,
+  sortLabel,
+  SearchField,
+  filterInputClass,
+  matchesPosition,
+  parseMin,
+  POSITION_OPTIONS,
+  type MetricHeader,
+  type PositionFilter,
+} from "@/components/ui/data-table";
+
+const HEADERS: MetricHeader[] = [
+  { label: "URL", sortKey: "url", defaultDir: "asc" },
+  { label: "Position", align: "right", sortKey: "position", defaultDir: "asc" },
+  { label: "Clicks", align: "right", sortKey: "clicks" },
+  { label: "Impressions", align: "right", sortKey: "impressions" },
+  { label: "CTR", align: "right", sortKey: "ctr" },
+];
+
+export interface PageRowData {
+  url: string;
+  position: number;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+export function PagesTable({
+  rows,
+  domain,
+}: {
+  rows: PageRowData[];
+  domain: string;
+}) {
+  const [search, setSearch] = useState("");
+  const [position, setPosition] = useState<PositionFilter>("all");
+  const [minClicks, setMinClicks] = useState("");
+  const [minImpressions, setMinImpressions] = useState("");
+  const { sort, toggle } = useTableSort({ key: "clicks", dir: "desc" });
+
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+  const minClicksNum = parseMin(minClicks);
+  const minImpressionsNum = parseMin(minImpressions);
+
+  const filtered = useMemo(() => {
+    const out = rows.filter((p) => {
+      if (deferredSearch && !p.url.toLowerCase().includes(deferredSearch)) return false;
+      if (!matchesPosition(p.position, position)) return false;
+      if (minClicksNum != null && p.clicks < minClicksNum) return false;
+      if (minImpressionsNum != null && p.impressions < minImpressionsNum) return false;
+      return true;
+    });
+    return sortRows(out, sort);
+  }, [rows, deferredSearch, position, minClicksNum, minImpressionsNum, sort]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-3">
+        <SearchField value={search} onChange={setSearch} placeholder="Filter by URL..." />
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            Position
+          </span>
+          <select
+            value={position}
+            onChange={(e) => setPosition(e.target.value as PositionFilter)}
+            className={`${filterInputClass} pr-8`}
+          >
+            {POSITION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            Min clicks
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={minClicks}
+            onChange={(e) => setMinClicks(e.target.value)}
+            placeholder="0"
+            className={`${filterInputClass} w-24`}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            Min impressions
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={minImpressions}
+            onChange={(e) => setMinImpressions(e.target.value)}
+            placeholder="0"
+            className={`${filterInputClass} w-24`}
+          />
+        </label>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="panel px-4 py-10 text-center">
+          <p className="font-medium text-foreground">No pages match</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Loosen the search or filters.
+          </p>
+        </div>
+      ) : (
+        <MetricTable
+          sort={sort}
+          onSort={toggle}
+          headers={HEADERS}
+          footer={`Showing ${filtered.length} of ${rows.length} pages · sorted by ${sortLabel(HEADERS, sort)}`}
+        >
+          {filtered.map((page) => {
+            const href = page.url.startsWith("http")
+              ? page.url
+              : `https://${domain}${page.url.startsWith("/") ? "" : "/"}${page.url}`;
+
+            return (
+              <tr key={page.url} className="transition-colors hover:bg-muted/25">
+                <td className="max-w-xl px-4 py-3">
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="break-all font-medium text-signal hover:underline"
+                  >
+                    {page.url}
+                  </a>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <PositionBadge position={page.position} />
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <NumCell value={page.clicks} />
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <NumCell value={page.impressions} />
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <CtrCell ctr={page.ctr} />
+                </td>
+              </tr>
+            );
+          })}
+        </MetricTable>
+      )}
+    </div>
+  );
+}

--- a/components/sites/saved-keywords-table.tsx
+++ b/components/sites/saved-keywords-table.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useDeferredValue, useMemo, useState } from "react";
+import { DeleteKeywordButton } from "@/components/sites/saved-keyword-actions";
+import {
+  PositionBadge,
+  MetricTable,
+  CtrCell,
+  NumCell,
+  useTableSort,
+  sortRows,
+  sortLabel,
+  SearchField,
+  type MetricHeader,
+} from "@/components/ui/data-table";
+
+const HEADERS: MetricHeader[] = [
+  { label: "Keyword", sortKey: "query", defaultDir: "asc" },
+  { label: "Notes" },
+  { label: "Position", align: "right", sortKey: "position", defaultDir: "asc" },
+  { label: "Clicks", align: "right", sortKey: "clicks" },
+  { label: "Impr.", align: "right", sortKey: "impressions" },
+  { label: "CTR", align: "right", sortKey: "ctr" },
+  { label: "Actions", align: "right" },
+];
+
+export interface SavedKeywordRowData {
+  id: string;
+  query: string;
+  notes: string | null;
+  position: number | null;
+  clicks: number | null;
+  impressions: number | null;
+  ctr: number | null;
+}
+
+export function SavedKeywordsTable({
+  rows,
+  siteId,
+}: {
+  rows: SavedKeywordRowData[];
+  siteId: string;
+}) {
+  const [search, setSearch] = useState("");
+  const { sort, toggle } = useTableSort({ key: "clicks", dir: "desc" });
+
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+  const filtered = useMemo(() => {
+    const out = deferredSearch
+      ? rows.filter(
+          (r) =>
+            r.query.toLowerCase().includes(deferredSearch) ||
+            (r.notes ?? "").toLowerCase().includes(deferredSearch)
+        )
+      : rows;
+    return sortRows(out, sort);
+  }, [rows, deferredSearch, sort]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-3">
+        <SearchField
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter by keyword or note..."
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="panel px-4 py-10 text-center">
+          <p className="font-medium text-foreground">No saved keywords match</p>
+          <p className="mt-1 text-sm text-muted-foreground">Loosen the search.</p>
+        </div>
+      ) : (
+        <MetricTable
+          sort={sort}
+          onSort={toggle}
+          headers={HEADERS}
+          footer={`Showing ${filtered.length} of ${rows.length} saved keywords · last 28 days aggregated · sorted by ${sortLabel(HEADERS, sort)}`}
+        >
+          {filtered.map((kw) => (
+            <tr key={kw.id} className="transition-colors hover:bg-muted/25">
+              <td className="px-4 py-3 font-medium text-foreground">{kw.query}</td>
+              <td className="max-w-xs truncate px-4 py-3 text-muted-foreground">
+                {kw.notes || "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {kw.position != null ? <PositionBadge position={kw.position} /> : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {kw.clicks != null ? <NumCell value={kw.clicks} /> : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {kw.impressions != null ? <NumCell value={kw.impressions} /> : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {kw.ctr != null ? <CtrCell ctr={kw.ctr} /> : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                <DeleteKeywordButton siteId={siteId} query={kw.query} />
+              </td>
+            </tr>
+          ))}
+        </MetricTable>
+      )}
+    </div>
+  );
+}

--- a/components/sites/vitals-table.tsx
+++ b/components/sites/vitals-table.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useDeferredValue, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  MetricTable,
+  useTableSort,
+  sortRows,
+  sortLabel,
+  SearchField,
+  type MetricHeader,
+} from "@/components/ui/data-table";
+
+const HEADERS: MetricHeader[] = [
+  { label: "URL", sortKey: "url", defaultDir: "asc" },
+  { label: "Score", align: "right", sortKey: "perfScore", defaultDir: "asc" },
+  { label: "LCP", align: "right", sortKey: "lcp" },
+  { label: "CLS", align: "right", sortKey: "cls" },
+  { label: "INP", align: "right", sortKey: "inp" },
+  { label: "TTFB", align: "right", sortKey: "ttfb" },
+  { label: "When", sortKey: "date" },
+];
+
+export interface VitalsRowData {
+  id: string;
+  url: string;
+  perfScore: number | null;
+  lcp: number | null;
+  cls: number | null;
+  inp: number | null;
+  ttfb: number | null;
+  /** ISO string — serialized across the RSC boundary */
+  date: string;
+}
+
+export function VitalsTable({ rows }: { rows: VitalsRowData[] }) {
+  const [search, setSearch] = useState("");
+  const { sort, toggle } = useTableSort({ key: "date", dir: "desc" });
+
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+  const filtered = useMemo(() => {
+    const out = deferredSearch
+      ? rows.filter((r) => r.url.toLowerCase().includes(deferredSearch))
+      : rows;
+    return sortRows(out, sort);
+  }, [rows, deferredSearch, sort]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-3">
+        <SearchField value={search} onChange={setSearch} placeholder="Filter by URL..." />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="panel px-4 py-10 text-center">
+          <p className="font-medium text-foreground">No reports match</p>
+          <p className="mt-1 text-sm text-muted-foreground">Loosen the search.</p>
+        </div>
+      ) : (
+        <MetricTable
+          sort={sort}
+          onSort={toggle}
+          headers={HEADERS}
+          footer={`Showing ${filtered.length} of ${rows.length} reports · sorted by ${sortLabel(HEADERS, sort)}`}
+        >
+          {filtered.map((r) => (
+            <tr key={r.id} className="hover:bg-muted/20">
+              <td className="max-w-xs truncate px-4 py-2.5 font-medium" title={r.url}>
+                {r.url}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                <span
+                  className={cn(
+                    (r.perfScore ?? 0) >= 90
+                      ? "text-signal"
+                      : (r.perfScore ?? 0) >= 50
+                        ? "text-warning"
+                        : "text-danger"
+                  )}
+                >
+                  {r.perfScore ?? "—"}
+                </span>
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                {r.lcp != null ? `${r.lcp.toFixed(2)}s` : "—"}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                {r.cls != null ? r.cls.toFixed(3) : "—"}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                {r.inp != null ? `${Math.round(r.inp)}ms` : "—"}
+              </td>
+              <td className="px-4 py-2.5 text-right font-data">
+                {r.ttfb != null ? `${r.ttfb.toFixed(2)}s` : "—"}
+              </td>
+              <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                {new Date(r.date).toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </MetricTable>
+      )}
+    </div>
+  );
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { positionBand, formatPosition, formatCtr } from "@/lib/seo-metrics";
 
@@ -18,14 +21,66 @@ export function PositionBadge({ position }: { position: number }) {
   );
 }
 
+export type SortDir = "asc" | "desc";
+export interface SortState {
+  key: string;
+  dir: SortDir;
+}
+export interface MetricHeader {
+  label: string;
+  align?: "left" | "right";
+  /** Present ⇒ the header is clickable and sorts by this key */
+  sortKey?: string;
+  /** Direction applied on first click (default "desc"; use "asc" for position/text) */
+  defaultDir?: SortDir;
+}
+
+/** Shared sort-state hook: click same column ⇒ flip, new column ⇒ its default dir. */
+export function useTableSort(initial: SortState) {
+  const [sort, setSort] = useState<SortState>(initial);
+  function toggle(key: string, defaultDir: SortDir = "desc") {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: defaultDir }
+    );
+  }
+  return { sort, setSort, toggle };
+}
+
+/** Human label for the active sort, for footers ("Score", not "perfScore"). */
+export function sortLabel(headers: MetricHeader[], sort: SortState): string {
+  const label = headers.find((h) => h.sortKey === sort.key)?.label ?? sort.key;
+  return `${label.toLowerCase()} ${sort.dir === "asc" ? "↑" : "↓"}`;
+}
+
+/** Generic comparator: numbers numerically, strings via localeCompare, null/undefined last. */
+export function sortRows<T>(rows: T[], sort: SortState): T[] {
+  const { key, dir } = sort;
+  const mul = dir === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const va = (a as Record<string, unknown>)[key];
+    const vb = (b as Record<string, unknown>)[key];
+    if (va == null && vb == null) return 0;
+    if (va == null) return 1;
+    if (vb == null) return -1;
+    if (typeof va === "number" && typeof vb === "number") return (va - vb) * mul;
+    return String(va).localeCompare(String(vb)) * mul;
+  });
+}
+
 export function MetricTable({
   headers,
   children,
   footer,
+  sort,
+  onSort,
 }: {
-  headers: { label: string; align?: "left" | "right" }[];
+  headers: MetricHeader[];
   children: React.ReactNode;
   footer?: React.ReactNode;
+  sort?: SortState;
+  onSort?: (key: string, defaultDir?: SortDir) => void;
 }) {
   return (
     <div className="panel overflow-hidden">
@@ -33,17 +88,41 @@ export function MetricTable({
         <table className="w-full min-w-[640px] text-sm">
           <thead>
             <tr className="border-b border-border/70 bg-muted/30">
-              {headers.map((h) => (
-                <th
-                  key={h.label}
-                  className={cn(
-                    "px-4 py-3 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground",
-                    h.align === "right" ? "text-right" : "text-left"
-                  )}
-                >
-                  {h.label}
-                </th>
-              ))}
+              {headers.map((h) => {
+                const sortable = h.sortKey != null && onSort != null;
+                const active = sortable && sort?.key === h.sortKey;
+                return (
+                  <th
+                    key={h.label}
+                    aria-sort={
+                      active ? (sort!.dir === "asc" ? "ascending" : "descending") : undefined
+                    }
+                    className={cn(
+                      "px-4 py-3 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground",
+                      h.align === "right" ? "text-right" : "text-left"
+                    )}
+                  >
+                    {sortable ? (
+                      <button
+                        type="button"
+                        onClick={() => onSort!(h.sortKey!, h.defaultDir)}
+                        className={cn(
+                          "inline-flex items-center gap-1 uppercase tracking-[0.14em] transition-colors hover:text-foreground",
+                          active && "text-foreground"
+                        )}
+                        title={`Sort by ${h.label}`}
+                      >
+                        {h.label}
+                        <span className={cn("text-[9px]", !active && "opacity-30")}>
+                          {active ? (sort!.dir === "asc" ? "▲" : "▼") : "↕"}
+                        </span>
+                      </button>
+                    ) : (
+                      h.label
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">{children}</tbody>
@@ -56,6 +135,59 @@ export function MetricTable({
       )}
     </div>
   );
+}
+
+export const filterInputClass =
+  "h-9 rounded-lg border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary";
+
+/** Shared search field used above every metric table. */
+export function SearchField({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <label className="flex min-w-56 flex-1 flex-col gap-1">
+      <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        Search
+      </span>
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder ?? "Filter..."}
+        className={filterInputClass}
+      />
+    </label>
+  );
+}
+
+export type PositionFilter = "all" | "top3" | "top10" | "11-20" | "20+";
+
+export const POSITION_OPTIONS: { value: PositionFilter; label: string }[] = [
+  { value: "all", label: "All positions" },
+  { value: "top3", label: "Top 3" },
+  { value: "top10", label: "Top 10" },
+  { value: "11-20", label: "11–20" },
+  { value: "20+", label: "20+" },
+];
+
+export function matchesPosition(position: number, filter: PositionFilter): boolean {
+  if (filter === "all") return true;
+  if (filter === "top3") return position > 0 && position <= 3;
+  if (filter === "top10") return position > 0 && position <= 10;
+  if (filter === "11-20") return position > 10 && position <= 20;
+  return position > 20;
+}
+
+export function parseMin(value: string): number | null {
+  if (value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
 export function CtrCell({ ctr }: { ctr: number }) {


### PR DESCRIPTION
## What

**Consistency across all list grids/tables**: every metric table in the app now shares the same sorting and search UX, extending the pattern the Keywords page introduced in #6 — and the column headers themselves become clickable:

- **Clickable sortable headers** on Keywords, Pages, Saved Keywords, Crawled pages (Site crawl) and Core Web Vitals. Click sorts by that column; click again flips direction. Active column shows ▲/▼, inactive ones show a muted ↕. `aria-sort` is set for screen readers.
- **Sensible first-click direction per column**: metrics sort best/highest first (`desc`), Position and text columns sort `asc`.
- **Consistent search/filter bar**: Pages gets the same bar as Keywords (search + position band + min clicks + min impressions — same columns, same semantics); Saved Keywords, Crawled pages and Vitals get a URL/keyword search. Footers show `Showing X of Y … sorted by <column> ↑/↓`, and every table keeps the empty-filter state.

## How

- The shared sort core lives in `components/ui/data-table.tsx`: `MetricTable` headers accept an optional `sortKey`/`defaultDir`, plus `useTableSort` (toggle state), `sortRows` (generic comparator — numbers numeric, strings localeCompare, null last) and `SearchField`. `POSITION_OPTIONS`/`matchesPosition`/`parseMin` moved there from `KeywordsTable` so Pages can reuse them unchanged.
- Server pages (`pages`, `saved-keywords`, `crawl`, `vitals`) now pass plain serializable rows to thin client table components, following the existing `KeywordsTable` pattern. Ownership checks and data fetching are untouched.
- `KeywordsTable` keeps its Sort by dropdown, now in sync with the header state.

No new dependencies, no schema or API changes.

## Testing

- `npm run lint` and `npx tsc --noEmit` pass (the pre-existing lint errors in `mcp/server.ts`/`scripts/seed-demo.ts` are untouched — none of the files in this PR have lint errors); production Docker build passes.
- Verified against a live instance (4 sites, real GSC data): sorted each column on all five tables and checked the row order numerically, toggled asc/desc, filtered (`Showing 4 of 54` etc.), and exercised the empty-filter states.

## Screenshots

Core Web Vitals sorted by Score ascending (worst first) — active column shows the arrow, inactive ones the muted ↕:

![Vitals sorted by score](https://raw.githubusercontent.com/rafaferreira/crawlseo/assets-pr14/pr-vitals-sorted.png)

Pages with the full Keywords-style filter bar:

![Pages with filters](https://raw.githubusercontent.com/rafaferreira/crawlseo/assets-pr14/pr-pages-filters.png)
