### PR TITLE
feat: expose crawl page limit in Run crawl UI

### DIFF
--- a/components/sites/action-buttons.tsx
+++ b/components/sites/action-buttons.tsx
@@ -5,20 +5,42 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+
+const PAGE_LIMIT_PRESETS = ["25", "50", "100", "200"] as const;
+const MAX_CUSTOM_PAGES = 2000;
+const MIN_CUSTOM_PAGES = 1;
 
 export function CrawlButton({ siteId }: { siteId: string }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState(false);
+  const [limitSelection, setLimitSelection] = useState("200");
+  const [customValue, setCustomValue] = useState("");
+
+  const isCustom = limitSelection === "custom";
+  const maxPages = isCustom
+    ? Math.max(MIN_CUSTOM_PAGES, Math.min(MAX_CUSTOM_PAGES, Math.floor(Number(customValue) || 200)))
+    : Number(limitSelection);
 
   async function run() {
     setLoading(true);
     setMsg(null);
     setErr(false);
     try {
-      const res = await fetch(`/api/sites/${siteId}/crawl`, { method: "POST" });
+      const res = await fetch(`/api/sites/${siteId}/crawl`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxPages }),
+      });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Crawl failed");
       setMsg(`Crawl started (ID: ${data.crawlId?.slice(0, 8)}...)`);
@@ -33,14 +55,40 @@ export function CrawlButton({ siteId }: { siteId: string }) {
 
   return (
     <div className="space-y-1">
-      <Button
-        size="sm"
-        variant="outline"
-        disabled={loading}
-        onClick={run}
-      >
-        {loading ? "Starting…" : "Run crawl"}
-      </Button>
+      <div className="flex items-center gap-2">
+        <Select value={limitSelection} onValueChange={(v) => v && setLimitSelection(v)}>
+          <SelectTrigger size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PAGE_LIMIT_PRESETS.map((n) => (
+              <SelectItem key={n} value={n}>
+                {n} pages
+              </SelectItem>
+            ))}
+            <SelectItem value="custom">Custom</SelectItem>
+          </SelectContent>
+        </Select>
+        {isCustom && (
+          <input
+            type="number"
+            min={MIN_CUSTOM_PAGES}
+            max={MAX_CUSTOM_PAGES}
+            placeholder="Pages"
+            value={customValue}
+            onChange={(e) => setCustomValue(e.target.value.replace(/\D/g, ""))}
+            className="h-7 w-20 rounded-lg border border-input bg-transparent px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+          />
+        )}
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={loading || (isCustom && (!customValue || Number(customValue) < MIN_CUSTOM_PAGES))}
+          onClick={run}
+        >
+          {loading ? "Starting…" : "Run crawl"}
+        </Button>
+      </div>
       {msg && (
         <p className={cn("text-atom-caption", err ? "text-danger" : "text-signal")}>
           {msg}


### PR DESCRIPTION
Fixes #16

## Problem

The crawl API route (`app/api/sites/[siteId]/crawl/route.ts`) already accepts an optional `maxPages` parameter in the request body, but the UI never exposed it. The "Run crawl" button sent a bare POST with no body, so every crawl used the default (~200 pages). Users had no way to run a quick 25-page audit or increase the limit without hitting the API directly.

## What changed

**`components/sites/action-buttons.tsx`** — `CrawlButton` component:

- Added a **page-limit selector** next to the "Run crawl" button using the existing `Select` component (`@base-ui/react`): presets **25 / 50 / 100 / 200 / Custom**.
- Selecting "Custom" reveals a number input for arbitrary values.
- The fetch call now sends `{ maxPages }` as JSON body with `Content-Type: application/json`.

**Validation (defense in depth):**
- Client-side: custom input is clamped to 1–2000, strips non-numeric characters, button is disabled when the custom field is empty or below 1.
- Server-side (unchanged, already existed): the API route validates `maxPages` is a number > 0, and the crawler engine clamps to `ABSOLUTE_MAX_PAGES` (2000).

**Default is 200** — existing behaviour is completely unchanged for users who don't touch the selector.

No changes to `app/(dashboard)/sites/[siteId]/crawl/page.tsx` (avoids conflict with PR #14).

---

Surfaced by the GitTested review (Aug 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)