### PR TITLE
ci: build amd64 only on pull requests, multi-arch on main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -58,7 +59,9 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # PRs: amd64-only (avoids flaky QEMU arm64 emulation).
+          # Pushes to main / tags: full multi-arch for the published image.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Why

The Docker CI workflow builds `linux/amd64,linux/arm64` on every event, including pull requests. The arm64 leg runs under QEMU emulation on amd64 GitHub runners, which intermittently crashes with SIGILL (exit code 132) when Prisma's native engine binaries hit instructions QEMU can't emulate. This causes flaky red CI on PRs that don't touch Docker at all (e.g. #19).

## What changed

Two changes to `.github/workflows/docker-publish.yml`, no Dockerfile changes:

1. **`platforms`** is now conditional: `linux/amd64` on PRs, `linux/amd64,linux/arm64` on pushes to main and tags. Multi-arch publishing to GHCR is unaffected.

2. **QEMU setup** is skipped on PRs since it's only needed for cross-platform emulation.

The workflow stays a single job — no duplication.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)