### PR TITLE
fix: copy prisma cli from builder instead of a second npm install in runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,6 @@ RUN npm run build
 FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
-COPY package-lock.json ./
-# Keep the migration CLI in the image instead of downloading it through npx at
-# container startup. Reading the version from the lockfile keeps it aligned with
-# the generated Prisma client.
-RUN npm install --global "prisma@$(node -p "require('./package-lock.json').packages['node_modules/prisma'].version")" \
-    && npm cache clean --force
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
@@ -35,8 +29,15 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+# Reuse the Prisma CLI already built in the deps/builder stages instead of
+# running a second npm install under QEMU emulation (which crashes with SIGILL
+# on arm64). Only the CLI package and its engine binaries are needed for
+# `prisma migrate deploy` at container startup.
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
+COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
-CMD ["sh", "-c", "prisma migrate deploy && node server.js"]
+CMD ["sh", "-c", "node_modules/.bin/prisma migrate deploy && node server.js"]


### PR DESCRIPTION
## Root cause

The Dockerfile runner stage ran `npm install --global prisma@...` to provide the CLI for `prisma migrate deploy` at container startup. This is a second, independent npm invocation under QEMU arm64 emulation (the first is `npm ci` in the deps stage). QEMU intermittently crashes with SIGILL (exit code 132) when Prisma's Rust-compiled native engine binaries trigger CPU instructions the emulator can't handle.

The deps stage `npm ci` also runs under QEMU but succeeds — the crash is specific to the global install in the runner stage. Removing this second npm invocation eliminates the SIGILL crash path.

## What changed

**Dockerfile runner stage:**

- **Removed** `npm install --global prisma@...` and the `COPY package-lock.json` that fed its version lookup. No runtime code reads `package-lock.json` or `package.json` — confirmed by grepping the full repo.
- **Added** three COPY lines that reuse the already-built Prisma CLI from the builder stage:
  - `node_modules/prisma` (CLI package)
  - `node_modules/@prisma/engines` (native engine binaries)
  - `node_modules/.bin/prisma` (bin entry point)
- **CMD** now calls `node_modules/.bin/prisma migrate deploy` (the standard bin entry point) instead of the bare `prisma` from the global install.

**Image size** is unchanged — same ~108 MB of Prisma data, copied from the builder layer rather than re-downloaded via npm.

## Verification

No Docker runtime was available on the development machine, so local build/run verification was not possible. CI is the check — the arm64 build should now succeed because the SIGILL-triggering npm install is gone.

## Dependency

This PR benefits from #22 (`ci: build amd64 only on pull requests`) merging first, so the PR build here runs amd64-only and isn't subject to the same QEMU flakiness it's fixing. The arm64 fix will be validated when this merges to main and the push build does the full multi-arch build.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)