### PR TITLE
chore: remove placeholder secrets from Dockerfile build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,9 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-# Next.js evaluates the Auth.js configuration while collecting build output.
-# These non-secret placeholders keep the image build independent of runtime
-# configuration; deployments provide the real values to the final stage.
-ENV DATABASE_URL=postgresql://crawlseo:crawlseo@localhost:5432/crawlseo
-ENV GOOGLE_CLIENT_ID=docker-build-placeholder
-ENV GOOGLE_CLIENT_SECRET=docker-build-placeholder
-ENV NEXTAUTH_SECRET=docker-build-placeholder
-RUN npx prisma generate
+# Prisma generate needs a syntactically valid DATABASE_URL but never connects.
+# Inline it so it does not persist as an image layer.
+RUN DATABASE_URL="postgresql://build:build@localhost/build" npx prisma generate
 RUN npm run build
 
 FROM base AS runner

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,7 +3,13 @@ import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "./db";
 
-if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
+// Skipped during `next build` so the Docker image can be built without real
+// credentials.  NEXT_PHASE is set by Next.js; SKIP_ENV_VALIDATION is a manual
+// escape hatch for other build toolchains.
+const isBuild =
+  process.env.NEXT_PHASE === "phase-production-build" ||
+  process.env.SKIP_ENV_VALIDATION === "1";
+if (!isBuild && (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET)) {
   throw new Error("Missing Google OAuth credentials");
 }
 


### PR DESCRIPTION
## Summary

- Remove `ENV GOOGLE_CLIENT_ID`, `ENV GOOGLE_CLIENT_SECRET`, and `ENV NEXTAUTH_SECRET` from the Dockerfile builder stage
- Inline `DATABASE_URL` onto the `prisma generate` RUN command with an obviously-fake value (`postgresql://build:build@localhost/build`) so it no longer persists as an image layer
- Gate the `lib/auth.ts` credential guard on `NEXT_PHASE` (set by Next.js only during `next build`) and `SKIP_ENV_VALIDATION` (manual escape hatch), so the build succeeds without OAuth env vars while the runtime guard is preserved

## What this does NOT fix

No secret ever leaked. The values were hardcoded placeholders (`docker-build-placeholder`), the workflow passes no `--build-arg`, and multi-stage `ENV` does not carry into the runner stage — the published ghcr image never contained them.

## Why this change matters

The pattern advertises "put secrets here" and invites a contributor to pass a real value via `--build-arg` later, which _would_ bake it into the image. This also silences the BuildKit `SecretsUsedInArgOrEnv` warning.

## Verification

The "Missing Google OAuth credentials" guard is preserved at runtime, verified four ways:

1. **Guard fires without credentials** — `npx tsx -e 'import "./lib/auth.ts"'` throws `Error: Missing Google OAuth credentials` when `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are absent
2. **Guard passes with credentials** — module loads cleanly when credentials are provided
3. **`NEXT_PHASE` does not leak into runtime** — the only assignment in all of Next.js is inside the build pipeline (`dist/build/index.js`); the standalone `server.js` has zero references to `NEXT_PHASE`
4. **No collision** — neither `NEXT_PHASE` nor `SKIP_ENV_VALIDATION` is referenced anywhere else in the codebase

## Test plan

- [ ] CI Docker build passes (no `SecretsUsedInArgOrEnv` warning)
- [ ] `npm run build` succeeds without `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, or `NEXTAUTH_SECRET` in env
- [ ] Runtime server still throws on missing credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)