### PR TITLE
fix: read site totals from Page model and respect GSC data lag

### DIFF
--- a/app/api/gsc/sync/route.ts
+++ b/app/api/gsc/sync/route.ts
@@ -5,7 +5,7 @@ import {
   fetchPageAnalytics,
   ReauthRequiredError,
 } from "@/lib/google";
-import { getDateRange } from "@/lib/date-utils";
+import { getDateRange, getDataLagDate } from "@/lib/date-utils";
 
 export async function POST(req: Request) {
   try {
@@ -37,8 +37,10 @@ export async function POST(req: Request) {
       );
     }
 
-    // Fetch last 28 days of data
-    const { start, end } = getDateRange(28);
+    // Fetch last 28 days of data — end at the data lag boundary (3 days ago)
+    // because Google's most recent 2-3 days are always incomplete.
+    const { start } = getDateRange(28);
+    const end = getDataLagDate();
 
     const [keywords, pages] = await Promise.all([
       fetchSearchAnalytics(

--- a/components/dashboard/traffic-chart.tsx
+++ b/components/dashboard/traffic-chart.tsx
@@ -184,6 +184,10 @@ export function TrafficChart({ siteId, days = 90 }: TrafficChartProps) {
           />
         </AreaChart>
       </ResponsiveContainer>
+
+      <p className="mt-3 text-atom-caption text-muted-foreground">
+        Google reports with a ~3 day delay; the most recent days are not shown yet.
+      </p>
     </div>
   );
 }

--- a/lib/seo-metrics.ts
+++ b/lib/seo-metrics.ts
@@ -67,17 +67,17 @@ function weightedPosition(
 }
 
 function aggregatePeriod(
-  rows: { clicks: number; impressions: number; position: number; query?: string }[]
+  rows: { clicks: number; impressions: number; position: number }[],
+  uniqueKeywords = 0
 ): PeriodMetrics {
   const clicks = rows.reduce((s, r) => s + r.clicks, 0);
   const impressions = rows.reduce((s, r) => s + r.impressions, 0);
-  const queries = new Set(rows.map((r) => r.query).filter(Boolean));
   return {
     clicks,
     impressions,
     avgPosition: weightedPosition(rows),
     avgCtr: impressions > 0 ? clicks / impressions : 0,
-    uniqueKeywords: queries.size,
+    uniqueKeywords,
   };
 }
 
@@ -97,35 +97,51 @@ export async function getSitePeriodMetrics(
   const currentRange = parseRange(days);
   const prevRange = previousRange(days);
 
-  const [currentRows, previousRows] = await Promise.all([
-    db.keyword.findMany({
-      where: {
-        siteId,
-        date: { gte: currentRange.start, lte: currentRange.end },
-      },
-      select: {
-        query: true,
-        clicks: true,
-        impressions: true,
-        position: true,
-      },
-    }),
-    db.keyword.findMany({
-      where: {
-        siteId,
-        date: { gte: prevRange.start, lte: prevRange.end },
-      },
-      select: {
-        query: true,
-        clicks: true,
-        impressions: true,
-        position: true,
-      },
-    }),
-  ]);
+  // Site-wide traffic totals come from the Page model (GSC page-level data),
+  // NOT Keyword. Google suppresses query text for low-volume searches
+  // ("anonymized queries"), so those searches never appear as Keyword rows.
+  // Page rows have no query dimension and include ALL traffic.
+  // Measured gap on real data: Keyword undercounts clicks by ~95% and
+  // impressions by ~63% vs Page.
+  const [currentPages, previousPages, currentKwCount, previousKwCount] =
+    await Promise.all([
+      db.page.findMany({
+        where: {
+          siteId,
+          date: { gte: currentRange.start, lte: currentRange.end },
+        },
+        select: { clicks: true, impressions: true, position: true },
+      }),
+      db.page.findMany({
+        where: {
+          siteId,
+          date: { gte: prevRange.start, lte: prevRange.end },
+        },
+        select: { clicks: true, impressions: true, position: true },
+      }),
+      // Unique keyword count still comes from Keyword — it's genuinely query-level.
+      db.keyword
+        .groupBy({
+          by: ["query"],
+          where: {
+            siteId,
+            date: { gte: currentRange.start, lte: currentRange.end },
+          },
+        })
+        .then((rows) => rows.length),
+      db.keyword
+        .groupBy({
+          by: ["query"],
+          where: {
+            siteId,
+            date: { gte: prevRange.start, lte: prevRange.end },
+          },
+        })
+        .then((rows) => rows.length),
+    ]);
 
-  const current = aggregatePeriod(currentRows);
-  const previous = aggregatePeriod(previousRows);
+  const current = aggregatePeriod(currentPages, currentKwCount);
+  const previous = aggregatePeriod(previousPages, previousKwCount);
 
   return {
     current,

--- a/lib/workers/gsc-sync.ts
+++ b/lib/workers/gsc-sync.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { fetchSearchAnalytics, fetchPageAnalytics } from "@/lib/google";
-import { getDateRange } from "@/lib/date-utils";
+import { getDateRange, getDataLagDate } from "@/lib/date-utils";
 
 interface SyncResult {
   success: boolean;
@@ -39,8 +39,10 @@ export async function syncGSCDataForSite(
       throw new Error("Site does not have GSC property connected");
     }
 
-    // Get date range
-    const { start, end } = getDateRange(daysBack);
+    // Get date range — end at the data lag boundary (3 days ago) because
+    // Google's most recent 2-3 days are always incomplete.
+    const { start } = getDateRange(daysBack);
+    const end = getDataLagDate();
 
     console.log(`[GSC Sync] Starting sync for site ${siteId}`);
     console.log(`[GSC Sync] Date range: ${start} to ${end}`);


### PR DESCRIPTION
## Summary

Site-wide clicks/impressions/position/CTR in `getSitePeriodMetrics()` were summed from Keyword rows. Google suppresses query text for low-volume searches ("anonymized queries"), so those searches never become Keyword rows at all. Measured on one site:

- **Full stored window** (2026-03-09 → 2026-08-06): Keyword summed to **4 clicks / 5,589 impressions** against Page's **87 / 15,165**.
- **Dashboard's 28-day window**: **1 click / 793 impressions** against **17 / 2,202**. The clicks figure was off by roughly 17×.

Page rows have no query dimension and aren't truncated, so they're the correct source for site-wide totals. Keyword is kept for genuinely query-level data (unique keyword counts, top keywords, cannibalization).

The sync now ends at `getDataLagDate()` (3 days ago) — that function already existed in `date-utils.ts` and was not being used. Google's most recent 2-3 days are always incomplete. Trailing rows synced under the old behaviour self-correct on the next sync run, since the upsert overwrites by `(siteId, url, date)`.

A caption is added below the traffic chart explaining the ~3 day delay so the line ending before today has a visible reason.

Position is impression-weighted (`weightedPosition()`) and CTR is `clicks / impressions` — both already correct, verified.

**Credit:** This was surfaced by reading [PR #11](https://github.com/crawlseo/crawlseo/pull/11) from @PrincipalJohnShepherd, who diagnosed the Keyword undercount independently in their GSC sync rewrite.

## Changes

**Commit 1 — `lib/seo-metrics.ts`**
- `getSitePeriodMetrics` reads clicks/impressions/position from `db.page` instead of `db.keyword`
- Unique keyword count still comes from `db.keyword.groupBy` (genuinely query-level)
- Comment explains WHY so nobody reverts this

**Commit 2 — sync + chart**
- `lib/workers/gsc-sync.ts` and `app/api/gsc/sync/route.ts`: sync end date capped at `getDataLagDate()`
- `components/dashboard/traffic-chart.tsx`: lag explanation caption below chart
- Read paths unchanged — they query whatever exists in the DB

## Test plan

- [ ] tsc clean
- [ ] eslint clean on all changed files
- [ ] vitest 30/30 pass
- [ ] SQL verification: dashboard 28-day totals now match Page model
- [ ] Verify traffic chart renders with caption text
- [ ] Verify `DataLagBadge` and chart caption are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)