### PR TITLE
fix: Select triggers show the raw value; site switcher can open upwards

### DIFF
--- a/components/sites/action-buttons.tsx
+++ b/components/sites/action-buttons.tsx
@@ -14,7 +14,13 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
-const PAGE_LIMIT_PRESETS = ["25", "50", "100", "200"] as const;
+const PAGE_LIMIT_ITEMS = [
+  { value: "25", label: "25 pages" },
+  { value: "50", label: "50 pages" },
+  { value: "100", label: "100 pages" },
+  { value: "200", label: "200 pages" },
+  { value: "custom", label: "Custom" },
+];
 const MAX_CUSTOM_PAGES = 2000;
 const MIN_CUSTOM_PAGES = 1;
 
@@ -56,17 +62,20 @@ export function CrawlButton({ siteId }: { siteId: string }) {
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-2">
-        <Select value={limitSelection} onValueChange={(v) => v && setLimitSelection(v)}>
+        <Select
+          value={limitSelection}
+          onValueChange={(v) => v && setLimitSelection(v)}
+          items={PAGE_LIMIT_ITEMS}
+        >
           <SelectTrigger size="sm">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {PAGE_LIMIT_PRESETS.map((n) => (
-              <SelectItem key={n} value={n}>
-                {n} pages
+            {PAGE_LIMIT_ITEMS.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
               </SelectItem>
             ))}
-            <SelectItem value="custom">Custom</SelectItem>
           </SelectContent>
         </Select>
         {isCustom && (

--- a/components/sites/select-labels.test.ts
+++ b/components/sites/select-labels.test.ts
@@ -1,0 +1,46 @@
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Base UI's Select.Value renders the raw value on first paint (popup not yet
+// mounted) unless the Root receives `items`. These tests render the closed
+// trigger the way the server does, which is exactly where the id/label bug
+// showed up.
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/sites/site-b/keywords",
+}));
+
+vi.mock("next-auth/react", () => ({ signIn: vi.fn() }));
+
+let SiteSwitcher: typeof import("./site-switcher").SiteSwitcher;
+let CrawlButton: typeof import("./action-buttons").CrawlButton;
+
+beforeAll(async () => {
+  ({ SiteSwitcher } = await import("./site-switcher"));
+  ({ CrawlButton } = await import("./action-buttons"));
+});
+
+function triggerText(html: string): string {
+  const match = html.match(/data-slot="select-trigger"[^>]*>([\s\S]*?)<\/button>/);
+  return match ? match[1].replace(/<[^>]+>/g, "") : "";
+}
+
+describe("Select triggers show labels, not raw values", () => {
+  const sites = [
+    { id: "site-a", domain: "a.example" },
+    { id: "site-b", domain: "b.example" },
+  ];
+
+  it("site switcher shows the domain of the site in the path", () => {
+    const html = renderToString(createElement(SiteSwitcher, { sites }));
+    expect(triggerText(html)).toContain("b.example");
+    expect(triggerText(html)).not.toContain("site-b");
+  });
+
+  it("crawl page-limit select shows the label of the default preset", () => {
+    const html = renderToString(createElement(CrawlButton, { siteId: "site-b" }));
+    expect(triggerText(html)).toContain("200 pages");
+  });
+});

--- a/components/sites/site-switcher.tsx
+++ b/components/sites/site-switcher.tsx
@@ -21,9 +21,8 @@ export function SiteSwitcher({ sites }: { sites: Site[] }) {
   if (sites.length === 0) return null;
 
   const match = pathname.match(/\/sites\/([^/]+)/);
-  const fromPath =
-    match?.[1] && sites.some((s) => s.id === match[1]) ? match[1] : undefined;
-  const selected = fromPath ?? sites[0].id;
+  const selected =
+    match?.[1] && sites.some((s) => s.id === match[1]) ? match[1] : null;
 
   function handleSiteChange(siteId: string | null) {
     if (!siteId) return;
@@ -54,19 +53,21 @@ export function SiteSwitcher({ sites }: { sites: Site[] }) {
     );
   }
 
+  const items = sites.map((site) => ({ value: site.id, label: site.domain }));
+
   return (
     <div>
       <p className="mb-1.5 px-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
         Switch site
       </p>
-      <Select value={selected} onValueChange={handleSiteChange}>
+      <Select value={selected} onValueChange={handleSiteChange} items={items}>
         <SelectTrigger className="w-full border-border/70 bg-panel">
-          <SelectValue />
+          <SelectValue placeholder="Choose a site" />
         </SelectTrigger>
-        <SelectContent>
-          {sites.map((site) => (
-            <SelectItem key={site.id} value={site.id}>
-              {site.domain}
+        <SelectContent alignItemWithTrigger={false}>
+          {items.map(({ value, label }) => (
+            <SelectItem key={value} value={value}>
+              {label}
             </SelectItem>
           ))}
         </SelectContent>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -18,6 +18,8 @@ function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   )
 }
 
+// Renders the raw value unless `Select` receives `items` (value → label);
+// it never reads the labels from the rendered `SelectItem` children.
 function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
   return (
     <SelectPrimitive.Value


### PR DESCRIPTION
## What

Two small UI bugs in the `Select`-based controls:

- **Site switcher showed the site id** (`cmshr9a3s010hms01d85y2mxk`) in the sidebar trigger instead of the domain. Same class of bug in the **Run crawl page-limit select** (#19), which showed `200` instead of `200 pages`.
- **Site switcher dropdown opened upwards** (covering the trigger and the logo) whenever the selected site was low in the list.

## How

Both are Base UI `Select` defaults, not app logic:

- `<Select.Value>` renders the **raw value** until the popup has mounted once, unless the root gets an `items` list to resolve labels from ([docs: Formatting the value](https://base-ui.com/react/components/select#formatting-the-value)). The popup is portaled and lazy, so on first paint the trigger showed the id. Fix: pass `items` to `Select` in both places, and render the `SelectItem`s from that same list so label and value can't drift. A comment on `SelectValue` in the wrapper documents the requirement, since the third `Select` (add-site modal) only works because its label happens to equal its value.
- With a readable label the old `?? sites[0].id` fallback became misleading: on routes without a site in the path (`/dashboard`, `/sites`) the trigger would name the first site as if it were active. It now passes `null` there and shows a `Choose a site` placeholder; picking a site still navigates as before.
- `alignItemWithTrigger` defaults to `true`, which positions the popup so the *selected item* overlaps the trigger (macOS-style). For a sidebar switcher that means the list climbs above the trigger as you select sites further down. Fix: `alignItemWithTrigger={false}` on the switcher's `SelectContent`, so it behaves like a normal dropdown (`side="bottom"` is already the wrapper default). The add-site modal and the crawl-limit select keep the default; they're short lists in the middle of the viewport.

No new dependencies, no schema or API changes. Same `@base-ui/react` version.

## Testing

- Regression test `components/sites/select-labels.test.ts`: renders both components with `react-dom/server` (first paint, popup closed, which is where the raw value showed) and asserts the trigger text. Fails on `main` (`site-b`, `200`), passes here (`b.example`, `200 pages`). Runs in the existing vitest node environment, no new dependencies.
- `npx tsc --noEmit`, `eslint` on the changed files and `npm test` (32 tests) pass locally, same steps as the `Test` workflow.
- Verified on a live instance built from this branch (6 sites, real GSC data): trigger shows the domain on first paint on every site page and sub-page, and the placeholder on `/dashboard`; crawl-limit trigger shows `200 pages`. Popup placement measured in the DOM with the last site selected: `listbox.top` (154px) is below `trigger.bottom` (150px), i.e. it opens downwards.
