### PR TITLE
refactor: drop the sidebar Properties list, which duplicates the site switcher

### DIFF
--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -115,33 +115,6 @@ export function SidebarNav({
         </div>
       ))}
 
-      {/* Properties quick list */}
-      {!collapsed && sites.length > 1 && (
-        <div>
-          <p className="mb-2 px-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            Properties
-          </p>
-          <div className="space-y-0.5">
-            {sites.slice(0, 6).map((s) => {
-              const active = activeSiteId === s.id;
-              return (
-                <Link
-                  key={s.id}
-                  href={`/sites/${s.id}`}
-                  className={cn(
-                    "block truncate rounded-xl px-3 py-2 text-sm transition",
-                    active
-                      ? "bg-sidebar-accent text-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                  )}
-                >
-                  {s.domain}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      )}
     </nav>
   );
 }


### PR DESCRIPTION
The sidebar lists every site twice. The **Switch site** dropdown at the top and
the **Properties** list at the bottom both link to `/sites/<id>`, so the same
navigation is offered in two places under two different names — and neither name
matches the third entry, **Sites**, which goes somewhere else entirely: the index
where sites are added, inspected and synced.

Three labels for two destinations is hard to read. "Site", "Properties" and
"Sites" all sound like the same thing, and only one of them is.

The list is also the weaker of the two duplicates:

- it slices to six entries, so a seventh site is hidden with nothing to say so
- it disappears when the sidebar is collapsed, while the switcher keeps working
- it only renders with more than one site, so its absence carries no meaning

Removing it leaves one way to switch sites and one way to reach the index.
Nothing else changes: the `sites` prop is still used to resolve the active site
for the workspace group, and `SidebarLink` still uses the `Link` and `cn`
imports.

The switcher's own rendering is fixed separately in #28; this change only removes
the duplicate.
