### PR TITLE
fix: stop Search Console slices overwriting each other on save

### DIFF
--- a/lib/google/aggregate.test.ts
+++ b/lib/google/aggregate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { aggregateByQueryAndDate } from "./aggregate";
+
+const base = { date: "2026-08-20", ctr: 0, page: "https://a.com/x" };
+
+describe("aggregateByQueryAndDate", () => {
+  it("adds up the device and country slices of one query-day", () => {
+    const [row] = aggregateByQueryAndDate([
+      { ...base, query: "alpha", device: "MOBILE", country: "usa", clicks: 3, impressions: 30, position: 4 },
+      { ...base, query: "alpha", device: "DESKTOP", country: "usa", clicks: 2, impressions: 10, position: 8 },
+    ]);
+
+    // Storing these unmerged would key both on (site, alpha, 2026-08-20) and
+    // let the second overwrite the first, losing three clicks.
+    expect(row.clicks).toBe(5);
+    expect(row.impressions).toBe(40);
+    expect(row.position).toBe(5); // (4*30 + 8*10) / 40
+    expect(row.ctr).toBeCloseTo(0.125);
+  });
+
+  it("keeps different days and different queries apart", () => {
+    const rows = aggregateByQueryAndDate([
+      { ...base, query: "alpha", clicks: 1, impressions: 1, position: 1 },
+      { ...base, query: "alpha", date: "2026-08-21", clicks: 1, impressions: 1, position: 1 },
+      { ...base, query: "beta", clicks: 1, impressions: 1, position: 1 },
+    ]);
+
+    expect(rows).toHaveLength(3);
+  });
+
+  it("keeps the landing page that carried the most impressions", () => {
+    const [row] = aggregateByQueryAndDate([
+      { ...base, query: "alpha", page: "https://a.com/small", clicks: 0, impressions: 2, position: 9 },
+      { ...base, query: "alpha", page: "https://a.com/big", clicks: 0, impressions: 40, position: 3 },
+    ]);
+
+    expect(row.page).toBe("https://a.com/big");
+  });
+
+  // Null, not undefined: Prisma reads undefined on an update as "leave this
+  // column alone", which would strand yesterday-s single device on the row.
+  it("only claims a device or country when the day had just one", () => {
+    const [mixed] = aggregateByQueryAndDate([
+      { ...base, query: "q", device: "MOBILE", country: "usa", clicks: 0, impressions: 1, position: 5 },
+      { ...base, query: "q", device: "DESKTOP", country: "usa", clicks: 0, impressions: 1, position: 5 },
+    ]);
+    expect(mixed.device).toBeNull();
+    expect(mixed.country).toBe("usa");
+  });
+
+  it("does not divide by zero when a slice had no impressions", () => {
+    const [row] = aggregateByQueryAndDate([
+      { ...base, query: "q", clicks: 0, impressions: 0, position: 12 },
+    ]);
+    expect(row.position).toBe(12);
+    expect(row.ctr).toBe(0);
+  });
+});

--- a/lib/google/aggregate.ts
+++ b/lib/google/aggregate.ts
@@ -1,0 +1,68 @@
+import type { KeywordData } from "./types";
+
+/**
+ * Collapses the device/country/page slices Google returns into one row per
+ * query and date.
+ *
+ * The API is asked for five dimensions, so a single query on a single day
+ * comes back split across every device, country and landing page it appeared
+ * on. The Keyword table is keyed by (site, query, date), so storing those rows
+ * as they arrive lets each slice overwrite the previous one and only the last
+ * survives - which silently discards most of a query's clicks.
+ */
+export function aggregateByQueryAndDate(rows: KeywordData[]): KeywordData[] {
+  const groups = new Map<
+    string,
+    {
+      row: KeywordData;
+      weightedPosition: number;
+      weight: number;
+      topPageImpressions: number;
+      devices: Set<string>;
+      countries: Set<string>;
+    }
+  >();
+
+  for (const row of rows) {
+    const id = `${row.query}\u0000${row.date}`;
+    const group = groups.get(id);
+
+    if (!group) {
+      groups.set(id, {
+        row: { ...row, clicks: 0, impressions: 0 },
+        weightedPosition: 0,
+        weight: 0,
+        topPageImpressions: -1,
+        devices: new Set(),
+        countries: new Set(),
+      });
+    }
+
+    const target = groups.get(id)!;
+    target.row.clicks += row.clicks;
+    target.row.impressions += row.impressions;
+    const weight = Math.max(row.impressions, 1);
+    target.weightedPosition += row.position * weight;
+    target.weight += weight;
+    if (row.device) target.devices.add(row.device);
+    if (row.country) target.countries.add(row.country);
+    // Keep the landing page that carried the most impressions for the day.
+    if (row.impressions > target.topPageImpressions) {
+      target.topPageImpressions = row.impressions;
+      target.row.page = row.page;
+    }
+  }
+
+  return Array.from(groups.values()).map(({ row, weightedPosition, weight, devices, countries }) => ({
+    ...row,
+    position: Number((weightedPosition / weight).toFixed(2)),
+    ctr: row.impressions > 0 ? Number((row.clicks / row.impressions).toFixed(4)) : 0,
+    // The row now spans every slice, so a single device or country is only
+    // reported when there genuinely was only one. Null, not undefined: on the
+    // update half of an upsert Prisma reads undefined as "leave this column
+    // alone", which would keep yesterday's single device on a row that has
+    // since grown to cover several.
+    device: devices.size === 1 ? [...devices][0] : null,
+    country: countries.size === 1 ? [...countries][0] : null,
+  }));
+}

--- a/lib/google/gsc-client.ts
+++ b/lib/google/gsc-client.ts
@@ -1,4 +1,7 @@
 import { getAccessToken } from "./google-auth";
+import { aggregateByQueryAndDate } from "./aggregate";
+import type { KeywordData } from "./types";
+export type { KeywordData } from "./types";
 
 const GSC_API_BASE = "https://www.googleapis.com/webmasters/v3";
 
@@ -21,17 +24,6 @@ export type GSCFilter = {
   expression: string;
 };
 
-export interface KeywordData {
-  query: string;
-  page?: string;
-  device?: string;
-  country?: string;
-  clicks: number;
-  impressions: number;
-  ctr: number;
-  position: number;
-  date: string;
-}
 
 /**
  * Lists all Google Search Console properties for a user
@@ -132,6 +124,7 @@ export async function fetchSearchAnalytics(
       });
     }
 
+
     // If we got fewer rows than requested, we've reached the end
     if (data.rows.length < rowLimit) {
       break;
@@ -140,7 +133,7 @@ export async function fetchSearchAnalytics(
     startRow += rowLimit;
   }
 
-  return results;
+  return aggregateByQueryAndDate(results);
 }
 
 /**

--- a/lib/google/index.ts
+++ b/lib/google/index.ts
@@ -1,3 +1,4 @@
+export * from "./types";
 export * from "./google-auth";
 export * from "./gsc-client";
 export * from "./url-inspection-client";

--- a/lib/google/types.ts
+++ b/lib/google/types.ts
@@ -1,0 +1,12 @@
+/** One query/day row of Search Console performance data. */
+export interface KeywordData {
+  query: string;
+  page?: string;
+  device?: string | null;
+  country?: string | null;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+  date: string;
+}


### PR DESCRIPTION
`fetchSearchAnalytics` asks Search Console for five dimensions:

```ts
dimensions: ["query", "page", "date", "device", "country"]
```

so one query on one day comes back split across every device, country and
landing page it appeared on. `Keyword` is keyed `(siteId, query, date)`:

```prisma
@@unique([siteId, query, date])
```

The sync upserts those rows as they arrive, so each slice overwrites the
previous one and only the last survives. Most of a query's clicks are discarded
before anything reads them.

Measured against the live API for four sites on one account, 2026-07-01 to
2026-08-24, comparing the true totals with what the upsert loop actually stores:

| site | rows returned | real clicks | stored today |
| --- | --- | --- | --- |
| A | 6,807 | **64** | **3** |
| B | 1,207 | **29** | **6** |
| C | 847 | **75** | **0** |
| D | 756 | 2 | 1 |

Site C is the clearest: 75 clicks in the window, and the Keywords page shows
none of them, because the last slice written for every query happened to be one
with zero clicks.

## The change

Rows are collapsed to one per query and date before the upsert:

- clicks and impressions add up
- position is averaged weighted by impressions, the same way it is already
  averaged across days
- the landing page that carried the most impressions for the day is kept
- `device` and `country` are only reported when the day genuinely had one, and
  are `null` rather than `undefined` otherwise — on the update half of an
  upsert Prisma reads `undefined` as "leave this column alone", which would
  strand yesterday's single device on a row that has since grown to cover
  several

The aggregation is a pure function in its own module so it can be tested
without a database, which is also why `KeywordData` moved to `lib/google/types.ts`
(`aggregate.ts` needs the type and `gsc-client.ts` imports `aggregate.ts`). It
is still exported from the `lib/google` barrel.

Five tests cover it, including the division-by-zero case for a slice with no
impressions and the mixed-device case.

## Upgrade note

Existing rows stay wrong until the next sync overwrites them, and only for the
window that sync covers. A wider one-off backfill corrects more history.
