### PR TITLE
fix(crawler): read HTML attributes written without quotes

### DIFF
--- a/lib/crawler/engine.test.ts
+++ b/lib/crawler/engine.test.ts
@@ -3,6 +3,7 @@ import {
   matchManagedInfra,
   issuesFromPage,
   computeHealthScore,
+  parseHtml,
   type PageSnapshot,
   type IssueInput,
 } from "./engine";
@@ -196,5 +197,160 @@ describe("computeHealthScore", () => {
     const issues = [issue("CRITICAL"), issue("WARNING"), issue("INFO")];
     // 100 - 8 - 3 - 1 = 88
     expect(computeHealthScore(issues, 5)).toBe(88);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  parseHtml — unquoted attribute values (HTML5 / minified output)    */
+/* ------------------------------------------------------------------ */
+
+describe("parseHtml with unquoted attribute values", () => {
+  // Shape produced by an HTML minifier: it drops the quotes on
+  // values without spaces (`name=description`) and keeps them where the value
+  // has spaces (`content="..."`), so both styles appear in the SAME tag.
+  const minified = [
+    "<html><head><title>Example Site</title>",
+    '<meta content="A description with spaces in it." name=description>',
+    "<link href=https://example.com/ rel=canonical>",
+    "<meta content=index,follow name=robots>",
+    "<link href=https://example.com/en/ hreflang=en rel=alternate>",
+    "</head><body><h1>Example Site</h1>",
+    "<a href=/contact/>Contact</a>",
+    "<a href=/pricing/ rel=nofollow>Pricing</a>",
+    "<a href=#top>Top</a>",
+    "<img src=/logo.png alt=Logo>",
+    "<img src=/decor.png>",
+    "</body></html>",
+  ].join("");
+
+  const page = parseHtml(
+    "https://example.com/",
+    minified,
+    200,
+    120,
+    minified.length,
+    null,
+    "https://example.com/"
+  );
+
+  it("reads a meta description written without quotes", () => {
+    expect(page.description).toBe("A description with spaces in it.");
+  });
+
+  it("reads a canonical written without quotes", () => {
+    expect(page.canonical).toBe("https://example.com/");
+  });
+
+  it("reads robots meta written without quotes", () => {
+    expect(page.robotsMeta).toBe("index,follow");
+    expect(page.indexable).toBe(true);
+  });
+
+  it("reads hreflang alternates written without quotes", () => {
+    expect(page.hreflangTags).toEqual([
+      { lang: "en", href: "https://example.com/en/" },
+    ]);
+  });
+
+  it("follows links written without quotes", () => {
+    expect(page.internalOutlinks).toEqual([
+      "https://example.com/contact",
+      "https://example.com/pricing",
+    ]);
+  });
+
+  it("still skips in-page anchors", () => {
+    expect(page.links.some((l) => l.targetUrl.includes("top"))).toBe(false);
+  });
+
+  it("detects rel=nofollow written without quotes", () => {
+    const nofollow = page.links.find((l) => l.targetUrl.endsWith("/pricing"));
+    expect(nofollow?.isNofollow).toBe(true);
+  });
+
+  it("counts only the image that really has no alt", () => {
+    expect(page.imageCount).toBe(2);
+    expect(page.imagesMissingAlt).toBe(1);
+  });
+});
+
+describe("parseHtml with quoted attribute values", () => {
+  const quoted = [
+    "<html><head><title>Quoted</title>",
+    '<meta name="description" content="Still works">',
+    '<link rel="canonical" href="https://example.com/">',
+    '</head><body><a href="/a" rel="nofollow noopener">A</a>',
+    '<img src="/x.png" alt="">',
+    "</body></html>",
+  ].join("");
+
+  const page = parseHtml(
+    "https://example.com/",
+    quoted,
+    200,
+    100,
+    quoted.length,
+    null,
+    "https://example.com/"
+  );
+
+  it("did not regress the quoted form", () => {
+    expect(page.description).toBe("Still works");
+    expect(page.canonical).toBe("https://example.com/");
+    expect(page.links[0]?.isNofollow).toBe(true);
+  });
+
+  it("still treats an empty alt as missing", () => {
+    expect(page.imagesMissingAlt).toBe(1);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  parseHtml — cases the quote-only patterns used to get right        */
+/* ------------------------------------------------------------------ */
+
+function parse(html: string) {
+  return parseHtml(
+    "https://example.com/",
+    html,
+    200,
+    100,
+    html.length,
+    null,
+    "https://example.com/"
+  );
+}
+
+describe("parseHtml attribute lookup edge cases", () => {
+  it("keeps scanning when the first matching tag lacks the wanted attribute", () => {
+    const page = parse(
+      '<meta name="robots"><meta name="robots" content="noindex">' +
+        '<link rel="canonical"><link rel="canonical" href="https://example.com/real">'
+    );
+    expect(page.robotsMeta).toBe("noindex");
+    expect(page.indexable).toBe(false);
+    expect(page.canonical).toBe("https://example.com/real");
+  });
+
+  it("tolerates a > inside a quoted attribute value", () => {
+    const page = parse('<meta name="description" content="Before > After">');
+    expect(page.description).toBe("Before > After");
+  });
+
+  it("does not read href written inside another attribute's value", () => {
+    const page = parse(`<a onclick="go('href=/tracker')" href="/real">x</a>`);
+    expect(page.internalOutlinks).toEqual(["https://example.com/real"]);
+  });
+
+  it("keeps the full query string of an unquoted href", () => {
+    const page = parse("<a href=/search?q=shoes&page=2>x</a>");
+    expect(page.internalOutlinks).toEqual([
+      "https://example.com/search?q=shoes&page=2",
+    ]);
+  });
+
+  it("treats a whitespace-only alt as present, like the quoted patterns did", () => {
+    const page = parse('<img src="/a.png" alt=" "><img src="/b.png">');
+    expect(page.imagesMissingAlt).toBe(1);
   });
 });

--- a/lib/crawler/engine.ts
+++ b/lib/crawler/engine.ts
@@ -183,6 +183,77 @@ function extractTag(html: string, re: RegExp): string | null {
   return m?.[1]?.trim() || null;
 }
 
+/*
+ * HTML5 allows three attribute value syntaxes: "double quoted", 'single
+ * quoted', and unquoted. Minifiers drop the quotes whenever the value has no
+ * spaces, so a real page can serve `<meta content="Some text" name=description>`
+ * — `content` keeps its quotes because the value has spaces, `name` loses them.
+ * A pattern that only knows the quoted form reports that tag as missing.
+ *
+ * One attribute: a name, optionally followed by a value in any of the three
+ * syntaxes HTML5 allows — "double quoted", 'single quoted', or unquoted. An
+ * unquoted value ends only at whitespace or `>`, so query strings survive
+ * (`href=/search?q=shoes&page=2`).
+ */
+const ATTR_RE = /([^\s"'>/=]+)(?:\s*=\s*("[^"]*"|'[^']*'|[^\s>]+))?/g;
+
+/** Strips the surrounding quotes from a raw attribute value, if any. */
+function unquote(raw: string): string {
+  const q = raw[0];
+  return (q === '"' || q === "'") && raw.length > 1 && raw.endsWith(q)
+    ? raw.slice(1, -1)
+    : raw;
+}
+
+/**
+ * Attributes of one tag, lower-cased names, first occurrence winning (browsers
+ * ignore later duplicates).
+ *
+ * Parsed positionally in a single pass rather than searched for by name: a
+ * name search matches text inside ANOTHER attribute's value, so
+ * `<a onclick="go('href=/tracker')" href="/real">` would yield `/tracker`.
+ * Accepts a whole tag or a bare attribute list.
+ */
+function parseAttrs(tag: string): Map<string, string> {
+  const body = tag.replace(/^<[^\s/>]*/, "").replace(/\/?>$/, "");
+  const out = new Map<string, string>();
+  for (const m of body.matchAll(ATTR_RE)) {
+    const name = m[1].toLowerCase();
+    if (!out.has(name)) out.set(name, m[2] === undefined ? "" : unquote(m[2]));
+  }
+  return out;
+}
+
+/**
+ * Every `<tag …>` in the document. The alternation lets a quoted value contain
+ * `>`, which is legal (`<meta content="Before > After" …>`); a plain `[^>]*`
+ * envelope would cut the tag in half there and lose the later attributes.
+ */
+function tagsNamed(html: string, tag: string): string[] {
+  return html.match(new RegExp(`<${tag}\\b(?:[^>"']|"[^"]*"|'[^']*')*>`, "gi")) ?? [];
+}
+
+/**
+ * Value of `attrName` on the first `<tag>` whose `name` attribute is `value`.
+ * Keeps scanning when a matching tag has no `attrName`, so an empty
+ * `<meta name=robots>` does not mask the real one that follows.
+ */
+function tagAttr(
+  html: string,
+  tag: string,
+  name: string,
+  value: string,
+  attrName: string
+): string | null {
+  for (const t of tagsNamed(html, tag)) {
+    const attrs = parseAttrs(t);
+    if (attrs.get(name)?.toLowerCase() !== value) continue;
+    const found = attrs.get(attrName);
+    if (found) return found;
+  }
+  return null;
+}
+
 function decodeEntities(s: string): string {
   return s
     .replace(/&amp;/g, "&")
@@ -210,7 +281,7 @@ function hashText(text: string): string {
 /*  Parse a fetched HTML page into a snapshot                         */
 /* ------------------------------------------------------------------ */
 
-function parseHtml(
+export function parseHtml(
   url: string,
   html: string,
   statusCode: number,
@@ -224,40 +295,16 @@ function parseHtml(
     ? decodeEntities(titleRaw.replace(/\s+/g, " ").trim())
     : null;
 
-  const description =
-    extractTag(
-      html,
-      /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["']/i
-    ) ||
-    extractTag(
-      html,
-      /<meta[^>]+content=["']([^"']*)["'][^>]+name=["']description["']/i
-    );
+  const description = tagAttr(html, "meta", "name", "description", "content");
 
   const h1s = [...html.matchAll(/<h1[^>]*>([\s\S]*?)<\/h1>/gi)].map((m) =>
     decodeEntities(stripTags(m[1])).slice(0, 200)
   );
 
-  const canonical =
-    extractTag(
-      html,
-      /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i
-    ) ||
-    extractTag(
-      html,
-      /<link[^>]+href=["']([^"']+)["'][^>]+rel=["']canonical["']/i
-    );
+  const canonical = tagAttr(html, "link", "rel", "canonical", "href");
 
   // robots meta
-  const robotsMeta =
-    extractTag(
-      html,
-      /<meta[^>]+name=["']robots["'][^>]+content=["']([^"']*)["']/i
-    ) ||
-    extractTag(
-      html,
-      /<meta[^>]+content=["']([^"']*)["'][^>]+name=["']robots["']/i
-    );
+  const robotsMeta = tagAttr(html, "meta", "name", "robots", "content");
 
   const hasSchema =
     /application\/ld\+json/i.test(html) ||
@@ -265,28 +312,20 @@ function parseHtml(
     /\bitemtype\b/i.test(html);
 
   // hreflang tags
-  const hreflangTags = [
-    ...html.matchAll(
-      /<link[^>]+rel=["']alternate["'][^>]+hreflang=["']([^"']+)["'][^>]+href=["']([^"']+)["'][^>]*>/gi
-    ),
-    ...html.matchAll(
-      /<link[^>]+href=["']([^"']+)["'][^>]+hreflang=["']([^"']+)["'][^>]+rel=["']alternate["'][^>]*>/gi
-    ),
-  ].map((m) => {
-    // The capture groups might be in different order depending on which regex matched
-    // First regex: hreflang is group 1, href is group 2
-    // Second regex: href is group 1, hreflang is group 2
-    if (m[0].indexOf("hreflang") < m[0].indexOf("href=")) {
-      return { lang: m[1], href: m[2] };
-    }
-    return { lang: m[2], href: m[1] };
-  });
+  const hreflangTags = tagsNamed(html, "link")
+    .map((tag) => parseAttrs(tag))
+    .filter((a) => a.get("rel")?.toLowerCase() === "alternate")
+    .map((a) => ({ lang: a.get("hreflang") ?? "", href: a.get("href") ?? "" }))
+    .filter((t) => t.lang !== "" && t.href !== "");
 
   // Images
-  const imgTags = [...html.matchAll(/<img\b[^>]*>/gi)].map((m) => m[0]);
+  const imgTags = tagsNamed(html, "img");
   const imageCount = imgTags.length;
+  // An empty alt still counts as missing, exactly as before: the old pattern
+  // required `[^"']+`. A whitespace-only alt still counts as PRESENT, also as
+  // before — values are not trimmed.
   const imagesMissingAlt = imgTags.filter(
-    (tag) => !/\balt\s*=\s*["'][^"']+["']/i.test(tag)
+    (tag) => !parseAttrs(tag).get("alt")
   ).length;
 
   // Body text and word count
@@ -308,14 +347,15 @@ function parseHtml(
   for (const m of anchorMatches) {
     const attrs = m[1];
     const anchorContent = m[2];
-    const hrefMatch = attrs.match(/href=["']([^"'#][^"']*)["']/i);
-    if (!hrefMatch) continue;
+    const tagAttrs = parseAttrs(attrs);
+    const href = tagAttrs.get("href");
+    if (!href || href.startsWith("#")) continue;
 
-    const abs = normalizeUrl(hrefMatch[1], url);
+    const abs = normalizeUrl(href, url);
     if (!abs) continue;
 
     const anchorText = decodeEntities(stripTags(anchorContent)).slice(0, 200) || null;
-    const isNofollow = /\brel=["'][^"']*nofollow[^"']*["']/i.test(attrs);
+    const isNofollow = /\bnofollow\b/i.test(tagAttrs.get("rel") ?? "");
     const isInternal = sameHost(abs, seedUrl);
 
     links.push({
@@ -884,7 +924,7 @@ async function executeCrawl(
       // Mixed content check on raw HTML
       if (
         page.url.startsWith("https://") &&
-        /(?:src|href)=["']http:\/\//i.test(res.html)
+        /(?:src|href)\s*=\s*["']?http:\/\//i.test(res.html)
       ) {
         issues.push({
           url: page.url,


### PR DESCRIPTION
## Problem

HTML5 lets attribute values go unquoted when they contain no spaces, and HTML minifiers take that offer. A minified page can serve:

```html
<meta content="A description with spaces in it." name=description>
<link href=https://example.com/ rel=canonical>
<a href=/contact/>Contact</a>
```

`content` keeps its quotes because the value has spaces; `name`, `rel` and `href` lose them. Browsers and search engine crawlers read this fine.

Every extraction pattern in `lib/crawler/engine.ts` required quotes (`name=["']description["']` and friends), so on a minified site the crawler:

- reports meta description, canonical and robots as **missing** while they are present
- extracts almost no links, leaving the internal link graph nearly empty

`issuesFromPage` then raises MISSING_DESCRIPTION / MISSING_CANONICAL on every page and `computeHealthScore` drives the site toward health 0 — for a site that is fully tagged.

Measured on two real minified pages:

| | 69 KB page | 130 KB page |
|---|---|---|
| meta description | `null` → read | `null` → read |
| canonical | `null` → read | `null` → read |
| robots | `null` → read | `null` → read |
| `<a>` links found | 1 → 26 | 5 → 38 |
| internal links | 0 → 8 | 0 → 13 |

## Fix

Rather than widening each quote-only pattern, the tag's attribute list is parsed once, positionally, into a map. That form avoids the traps a widened pattern walks into:

- values are read in all three forms HTML5 allows, and an unquoted value ends only at whitespace or `>`, so query strings survive (`href=/search?q=shoes&page=2`)
- a name is never matched inside another attribute's **value** — a name-anywhere search reads `/tracker` from `<a onclick="go('href=/tracker')" href="/real">`
- the tag envelope tolerates `>` inside a quoted value (`content="Before > After"`), which a plain `[^>]*` cuts in half
- a meta/link lookup keeps scanning when a matching tag carries no such attribute, so an empty `<meta name=robots>` cannot mask the real one that follows

This also deletes the duplicated reversed-attribute-order patterns and the hreflang group-ordering workaround.

## Preserved on purpose

- an empty `alt` still counts as missing; a whitespace-only `alt` still counts as present
- in-page `#anchor` links are still skipped
- the quoted form keeps working

## Tests

`parseHtml` is exported so the parser can be tested directly. 15 new tests, all proven by running them against the previous implementation. `npx tsc --noEmit` clean, `next build` clean, `eslint` on the touched files: 0 errors.