### PR TITLE
fix: site overview no longer hides a site that has pages but no keywords

### DIFF
--- a/app/(dashboard)/sites/[siteId]/page.test.ts
+++ b/app/(dashboard)/sites/[siteId]/page.test.ts
@@ -1,0 +1,65 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+// Search Console anonymises the query dimension on low-traffic properties, so
+// a sync can legitimately store pages and zero keywords. The overview used to
+// gate on keywords alone and told such sites to "run a sync" forever.
+
+const counts = vi.hoisted(() => ({ keywords: 0, pages: 0 }));
+
+vi.mock("@/lib/auth", () => ({ auth: async () => ({ user: { id: "user-1" } }) }));
+vi.mock("@/lib/db", () => ({
+  db: {
+    site: {
+      findUnique: async () => ({
+        userId: "user-1",
+        domain: "a.example",
+        gscProperty: "https://a.example/",
+        _count: counts,
+      }),
+    },
+    crawl: { findFirst: async () => null },
+    vitalsReport: { findFirst: async () => null },
+  },
+}));
+vi.mock("@/lib/seo-opportunities", () => ({
+  getAllOpportunities: async () => ({ feed: [] }),
+}));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/sites/site-a",
+}));
+vi.mock("next-auth/react", () => ({ signIn: vi.fn() }));
+// Async server components cannot go through renderToString; they are not
+// what this test is about.
+vi.mock("@/components/dashboard/metrics", () => ({ DashboardMetrics: () => null }));
+vi.mock("@/components/dashboard/traffic-chart", () => ({ TrafficChart: () => null }));
+vi.mock("@/components/dashboard/top-keywords", () => ({ TopKeywords: () => null }));
+
+import SiteOverviewPage from "./page";
+
+async function render(next: typeof counts): Promise<string> {
+  Object.assign(counts, next);
+  const tree = await SiteOverviewPage({ params: Promise.resolve({ siteId: "site-a" }) });
+  return renderToString(tree);
+}
+
+describe("site overview empty state", () => {
+  it("shows the empty state before any sync", async () => {
+    const html = await render({ keywords: 0, pages: 0 });
+    expect(html).toContain("Waiting for GSC data");
+    expect(html).not.toContain("Crawl health");
+  });
+
+  it("renders the overview when the sync stored pages but no keywords", async () => {
+    const html = await render({ keywords: 0, pages: 27 });
+    expect(html).not.toContain("Waiting for GSC data");
+    expect(html).toContain("Crawl health");
+  });
+
+  it("renders the overview when the sync stored keywords", async () => {
+    const html = await render({ keywords: 5, pages: 3 });
+    expect(html).toContain("Crawl health");
+  });
+});

--- a/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/page.tsx
@@ -30,7 +30,7 @@ export default async function SiteOverviewPage({ params }: SitePageProps) {
       userId: true,
       domain: true,
       gscProperty: true,
-      _count: { select: { keywords: true } },
+      _count: { select: { keywords: true, pages: true } },
     },
   });
 
@@ -50,10 +50,11 @@ export default async function SiteOverviewPage({ params }: SitePageProps) {
     select: { perfScore: true, lcp: true, url: true },
   });
 
-  const opportunities =
-    site._count.keywords > 0
-      ? await getAllOpportunities(siteId)
-      : null;
+  // Search Console anonymises the query dimension on low-traffic sites, so a
+  // synced site can have pages but no keywords. Either one means data arrived.
+  const hasData = site._count.keywords > 0 || site._count.pages > 0;
+
+  const opportunities = hasData ? await getAllOpportunities(siteId) : null;
 
   return (
     <div>
@@ -92,7 +93,7 @@ export default async function SiteOverviewPage({ params }: SitePageProps) {
         ))}
       </div>
 
-      {site._count.keywords === 0 ? (
+      {!hasData ? (
         <EmptyState
           icon="↻"
           title="Waiting for GSC data"


### PR DESCRIPTION
## Problem

Search Console anonymises the `query` dimension on low-traffic properties, so a sync can legitimately return landing pages and **zero** keywords (the sync log reads e.g. `Fetched 0 keyword records and 27 page records`). The site overview gated on `_count.keywords` alone, so such a site stayed on "Waiting for GSC data — run a sync" forever, while the Pages, Crawl and Vitals tabs already showed data.

## Fix

`app/(dashboard)/sites/[siteId]/page.tsx`: count `pages` too and gate the empty state and the opportunities query on either count. Everything under the gate already handles an empty keyword set (`TopKeywords` prints "No keyword data yet"; metrics read the Page model since #26).

## Test

`page.test.ts` renders the page through `react-dom/server` with a mocked `db`/`auth` (same approach as `select-labels.test.ts`). Three cases: nothing synced → empty state; pages but no keywords → overview; keywords → overview. The middle case fails on `main` and passes here. `tsc` and `eslint` clean.
