### PR TITLE
feat: Bing Webmaster Tools as a second data source

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -125,6 +125,34 @@ Copy `.env.example` to `.env.local` and update:
    - Authorized redirect URIs: `http://localhost:3000/api/auth/callback/google`
 5. Copy Client ID and Client Secret to `.env.local`
 
+## Bing Webmaster Tools Setup
+
+Bing is optional and free. It reports queries, pages and crawl statistics that
+Search Console either anonymises or does not expose at all.
+
+1. Sign in at [Bing Webmaster Tools](https://www.bing.com/webmasters) and verify
+   the site.
+2. **Settings → API Access → API Key → Generate**. One key covers every verified
+   site on the account, and generating a new one invalidates the old.
+3. In CrawlSEO, open a site's **Settings → External API Keys → Bing Webmaster
+   Tools**, paste the key and save. **Test Connection** calls `GetUserSites`,
+   which costs nothing and needs no site.
+4. Under **Bing Webmaster property**, pick the property for this site and sync.
+
+The property URL often differs from the Search Console one — Bing may know
+`https://example.com/` where Search Console knows `https://www.example.com/` —
+so the two are stored separately.
+
+Two things about Bing's data are worth knowing when reading the numbers:
+
+- `GetQueryStats` and `GetPageStats` report **weekly** buckets ending on a
+  Friday, and accept no date range: every call returns the full history. A
+  window counts the buckets whose end date falls inside it, so its edges are
+  approximate by up to six days. Site traffic and crawl stats are daily.
+- In `GetCrawlStats`, only `CrawledPages` is a per-day count. The status fields
+  are running snapshots of the URLs Bing knows in each state, so they are
+  reported as a latest value plus its movement, never summed.
+
 ## Testing
 
 ### Manual Testing Checklist

--- a/app/(dashboard)/sites/[siteId]/settings/page.tsx
+++ b/app/(dashboard)/sites/[siteId]/settings/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { PageHeader } from "@/components/ui/page-header";
 import { DeleteSiteButton } from "@/components/sites/delete-site-button";
 import { ApiKeysSection } from "@/components/settings/api-keys-section";
+import { BingSiteSection } from "@/components/settings/bing-site-section";
 
 interface Props {
   params: Promise<{ siteId: string }>;
@@ -19,6 +20,7 @@ export default async function SettingsPage({ params }: Props) {
       userId: true,
       domain: true,
       gscProperty: true,
+      bingSite: true,
       createdAt: true,
       _count: {
         select: {
@@ -41,6 +43,7 @@ export default async function SettingsPage({ params }: Props) {
   });
   const apiKeyStatus: Record<string, { connected: boolean; updatedAt?: string }> = {
     dataforseo: { connected: false },
+    bing: { connected: false },
   };
   for (const key of apiKeys) {
     apiKeyStatus[key.provider] = {
@@ -75,6 +78,12 @@ export default async function SettingsPage({ params }: Props) {
               </dd>
             </div>
             <div className="flex justify-between">
+              <dt className="text-muted-foreground">Bing property</dt>
+              <dd className="font-medium text-foreground">
+                {site.bingSite || "Not connected"}
+              </dd>
+            </div>
+            <div className="flex justify-between">
               <dt className="text-muted-foreground">Added</dt>
               <dd className="font-medium text-foreground">
                 {new Date(site.createdAt).toLocaleDateString(undefined, {
@@ -89,6 +98,13 @@ export default async function SettingsPage({ params }: Props) {
 
         {/* External API Keys */}
         <ApiKeysSection initialStatus={apiKeyStatus} />
+
+        {/* Bing Webmaster property */}
+        <BingSiteSection
+          siteId={siteId}
+          bingSite={site.bingSite}
+          keyConnected={apiKeyStatus.bing.connected}
+        />
 
         {/* Data summary */}
         <div className="panel p-5">

--- a/app/api/bing/sites/route.ts
+++ b/app/api/bing/sites/route.ts
@@ -1,0 +1,30 @@
+import { auth } from "@/lib/auth";
+import { BingKeyMissingError, listBingSites } from "@/lib/bing";
+
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    return Response.json(await listBingSites(session.user.id));
+  } catch (error) {
+    if (error instanceof BingKeyMissingError) {
+      return Response.json(
+        { error: error.message, code: "BING_KEY_MISSING" },
+        { status: 400 }
+      );
+    }
+
+    console.error("Error listing Bing sites:", error);
+
+    return Response.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to list Bing sites",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/bing/sync/route.ts
+++ b/app/api/bing/sync/route.ts
@@ -1,5 +1,4 @@
 import { auth } from "@/lib/auth";
-import { BingKeyMissingError } from "@/lib/bing";
 import { syncBingDataForSite } from "@/lib/workers/bing-sync";
 
 export async function POST(req: Request) {
@@ -23,13 +22,6 @@ export async function POST(req: Request) {
 
     return Response.json(result);
   } catch (error) {
-    if (error instanceof BingKeyMissingError) {
-      return Response.json(
-        { error: error.message, code: "BING_KEY_MISSING" },
-        { status: 400 }
-      );
-    }
-
     console.error("Bing sync error:", error);
 
     return Response.json(

--- a/app/api/bing/sync/route.ts
+++ b/app/api/bing/sync/route.ts
@@ -1,0 +1,40 @@
+import { auth } from "@/lib/auth";
+import { BingKeyMissingError } from "@/lib/bing";
+import { syncBingDataForSite } from "@/lib/workers/bing-sync";
+
+export async function POST(req: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { siteId } = (await req.json()) as { siteId?: string };
+    if (!siteId) {
+      return Response.json({ error: "Missing siteId" }, { status: 400 });
+    }
+
+    const result = await syncBingDataForSite(session.user.id, siteId);
+
+    if (!result.success) {
+      return Response.json(result, { status: 400 });
+    }
+
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof BingKeyMissingError) {
+      return Response.json(
+        { error: error.message, code: "BING_KEY_MISSING" },
+        { status: 400 }
+      );
+    }
+
+    console.error("Bing sync error:", error);
+
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Bing sync failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/sites/[siteId]/route.test.ts
+++ b/app/api/sites/[siteId]/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Changing the Bing property wipes the old property's rows. The wipe and the
+// site update have to commit together, or a failed update (say a duplicate
+// domain) leaves the old property with no history.
+
+const db = vi.hoisted(() => ({
+  site: {
+    findUnique: vi.fn(async () => ({ userId: "user-1", bingSite: "https://old.example/" })),
+    update: vi.fn(() => "update"),
+  },
+  bingSearchWeekly: { deleteMany: vi.fn(() => "delete-weekly") },
+  bingDaily: { deleteMany: vi.fn(() => "delete-daily") },
+  $transaction: vi.fn(async (ops: unknown[]) => ops.map(() => ({ id: "site-a" }))),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: async () => ({ user: { id: "user-1" } }) }));
+vi.mock("@/lib/db", () => ({ db }));
+
+import { PUT } from "./route";
+
+function put(body: object) {
+  return PUT(
+    new Request("http://localhost/api/sites/site-a", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ siteId: "site-a" }) }
+  );
+}
+
+describe("PUT /api/sites/[siteId] with a new Bing property", () => {
+  it("wipes the old rows in the same transaction as the update", async () => {
+    const res = await put({ bingSite: "https://new.example/" });
+    expect(res.status).toBe(200);
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+    expect(db.$transaction).toHaveBeenCalledWith([
+      "delete-weekly",
+      "delete-daily",
+      "update",
+    ]);
+  });
+
+  it("rejects a property that is not an http(s) URL", async () => {
+    const res = await put({ bingSite: "ftp://new.example/" });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/sites/[siteId]/route.test.ts
+++ b/app/api/sites/[siteId]/route.test.ts
@@ -41,6 +41,13 @@ describe("PUT /api/sites/[siteId] with a new Bing property", () => {
     ]);
   });
 
+  it("rejects a property that is not a string without touching the rows", async () => {
+    db.$transaction.mockClear();
+    expect((await put({ bingSite: 0 })).status).toBe(400);
+    expect((await put({ bingSite: ["https://new.example/"] })).status).toBe(400);
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
   it("rejects a property that is not an http(s) URL", async () => {
     const res = await put({ bingSite: "ftp://new.example/" });
     expect(res.status).toBe(400);

--- a/app/api/sites/[siteId]/route.ts
+++ b/app/api/sites/[siteId]/route.ts
@@ -91,6 +91,9 @@ export async function PUT(
     // Stored Bing rows are keyed by site, not by property, so pointing the site
     // at a different property would blend two properties' history - and page
     // URLs from both would normalise to the same key and count twice.
+    if (bingSite !== undefined && typeof bingSite !== "string") {
+      return Response.json({ error: "bingSite must be a string" }, { status: 400 });
+    }
     const nextBingSite = bingSite === undefined ? undefined : bingSite || null;
     // The picker only offers properties the account owns, but the endpoint is
     // reachable directly: a value that is not a URL syncs nothing and looks

--- a/app/api/sites/[siteId]/route.ts
+++ b/app/api/sites/[siteId]/route.ts
@@ -96,22 +96,21 @@ export async function PUT(
     // reachable directly: a value that is not a URL syncs nothing and looks
     // exactly like a site with no Bing data.
     if (nextBingSite !== null && nextBingSite !== undefined) {
-      const parsed = URL.parse?.(nextBingSite) ?? null;
-      if (!parsed || !/^https?:$/.test(parsed.protocol)) {
+      let protocol = "";
+      try {
+        protocol = new URL(nextBingSite).protocol;
+      } catch {}
+      if (!/^https?:$/.test(protocol)) {
         return Response.json(
           { error: "bingSite must be an http(s) URL" },
           { status: 400 }
         );
       }
     }
-    if (nextBingSite !== undefined && nextBingSite !== site.bingSite) {
-      await db.$transaction([
-        db.bingSearchWeekly.deleteMany({ where: { siteId } }),
-        db.bingDaily.deleteMany({ where: { siteId } }),
-      ]);
-    }
+    const propertyChanged =
+      nextBingSite !== undefined && nextBingSite !== site.bingSite;
 
-    const updated = await db.site.update({
+    const update = db.site.update({
       where: { id: siteId },
       data: {
         ...(domain && { domain }),
@@ -127,6 +126,17 @@ export async function PUT(
         updatedAt: true,
       },
     });
+    // The wipe and the update commit together: if the update fails (say a
+    // duplicate domain), the old property keeps its history.
+    const updated = propertyChanged
+      ? (
+          await db.$transaction([
+            db.bingSearchWeekly.deleteMany({ where: { siteId } }),
+            db.bingDaily.deleteMany({ where: { siteId } }),
+            update,
+          ])
+        )[2]
+      : await update;
 
     return Response.json(updated);
   } catch (error) {

--- a/app/api/sites/[siteId]/route.ts
+++ b/app/api/sites/[siteId]/route.ts
@@ -75,28 +75,55 @@ export async function PUT(
     // Verify ownership
     const site = await db.site.findUnique({
       where: { id: siteId },
-      select: { userId: true },
+      select: { userId: true, bingSite: true },
     });
 
     if (!site || site.userId !== session.user.id) {
       return Response.json({ error: "Unauthorized" }, { status: 403 });
     }
 
-    const { domain, gscProperty } = (await req.json()) as {
+    const { domain, gscProperty, bingSite } = (await req.json()) as {
       domain?: string;
       gscProperty?: string;
+      bingSite?: string;
     };
+
+    // Stored Bing rows are keyed by site, not by property, so pointing the site
+    // at a different property would blend two properties' history - and page
+    // URLs from both would normalise to the same key and count twice.
+    const nextBingSite = bingSite === undefined ? undefined : bingSite || null;
+    // The picker only offers properties the account owns, but the endpoint is
+    // reachable directly: a value that is not a URL syncs nothing and looks
+    // exactly like a site with no Bing data.
+    if (nextBingSite !== null && nextBingSite !== undefined) {
+      const parsed = URL.parse?.(nextBingSite) ?? null;
+      if (!parsed || !/^https?:$/.test(parsed.protocol)) {
+        return Response.json(
+          { error: "bingSite must be an http(s) URL" },
+          { status: 400 }
+        );
+      }
+    }
+    if (nextBingSite !== undefined && nextBingSite !== site.bingSite) {
+      await db.$transaction([
+        db.bingSearchWeekly.deleteMany({ where: { siteId } }),
+        db.bingDaily.deleteMany({ where: { siteId } }),
+      ]);
+    }
 
     const updated = await db.site.update({
       where: { id: siteId },
       data: {
         ...(domain && { domain }),
         ...(gscProperty && { gscProperty }),
+        // An empty string clears the connection; undefined leaves it alone.
+        ...(nextBingSite !== undefined && { bingSite: nextBingSite }),
       },
       select: {
         id: true,
         domain: true,
         gscProperty: true,
+        bingSite: true,
         updatedAt: true,
       },
     });

--- a/app/api/user/api-keys/route.test.ts
+++ b/app/api/user/api-keys/route.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The provider allow-list is a plain object: without hasOwn, "constructor" and
+// "__proto__" pass as providers. Removing the Bing key also disconnects every
+// property that key served.
+
+const db = vi.hoisted(() => ({
+  apiKey: {
+    upsert: vi.fn(async () => ({ provider: "x", updatedAt: new Date() })),
+    delete: vi.fn(() => "delete-key"),
+  },
+  site: { updateMany: vi.fn(() => "clear-properties") },
+  bingSearchWeekly: { deleteMany: vi.fn(() => "delete-weekly") },
+  bingDaily: { deleteMany: vi.fn(() => "delete-daily") },
+  $transaction: vi.fn(async (ops: unknown[]) => ops),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: async () => ({ user: { id: "user-1" } }) }));
+vi.mock("@/lib/db", () => ({ db }));
+vi.mock("@/lib/encryption", () => ({ encrypt: (v: string) => `enc:${v}` }));
+
+import { DELETE, POST } from "./route";
+
+const json = (method: string, body: object) =>
+  new Request("http://localhost/api/user/api-keys", {
+    method,
+    body: JSON.stringify(body),
+  });
+
+describe("api-keys provider allow-list", () => {
+  it("rejects Object.prototype names as providers", async () => {
+    for (const provider of ["constructor", "__proto__", "toString"]) {
+      expect((await POST(json("POST", { provider, login: "x" }))).status).toBe(400);
+      expect((await DELETE(json("DELETE", { provider }))).status).toBe(400);
+    }
+    expect(db.apiKey.upsert).not.toHaveBeenCalled();
+    expect(db.apiKey.delete).not.toHaveBeenCalled();
+  });
+
+  it("removing the Bing key disconnects its properties in one transaction", async () => {
+    const res = await DELETE(json("DELETE", { provider: "bing" }));
+    expect(res.status).toBe(200);
+    expect(db.$transaction).toHaveBeenCalledWith([
+      "delete-weekly",
+      "delete-daily",
+      "clear-properties",
+      "delete-key",
+    ]);
+  });
+});

--- a/app/api/user/api-keys/route.ts
+++ b/app/api/user/api-keys/route.ts
@@ -52,7 +52,11 @@ export async function POST(req: Request) {
       password?: string;
     };
 
-    const config = body.provider ? PROVIDERS[body.provider] : undefined;
+    // hasOwn: a plain object also answers for "constructor" and "__proto__".
+    const config =
+      body.provider && Object.hasOwn(PROVIDERS, body.provider)
+        ? PROVIDERS[body.provider]
+        : undefined;
     if (!body.provider || !config) {
       return Response.json({ error: "Unsupported provider" }, { status: 400 });
     }
@@ -103,18 +107,29 @@ export async function DELETE(req: Request) {
     }
 
     const body = (await req.json()) as { provider?: string };
-    if (!body.provider) {
-      return Response.json({ error: "Missing provider" }, { status: 400 });
+    if (!body.provider || !Object.hasOwn(PROVIDERS, body.provider)) {
+      return Response.json({ error: "Unsupported provider" }, { status: 400 });
     }
 
-    await db.apiKey.delete({
-      where: {
-        userId_provider: {
-          userId: session.user.id,
-          provider: body.provider,
-        },
-      },
+    const userId = session.user.id;
+    const deleteKey = db.apiKey.delete({
+      where: { userId_provider: { userId, provider: body.provider } },
     });
+    if (body.provider === "bing") {
+      // Without a key no property can sync, and a key from another account
+      // will not see these properties: disconnect them with the key.
+      await db.$transaction([
+        db.bingSearchWeekly.deleteMany({ where: { site: { userId } } }),
+        db.bingDaily.deleteMany({ where: { site: { userId } } }),
+        db.site.updateMany({
+          where: { userId, bingSite: { not: null } },
+          data: { bingSite: null },
+        }),
+        deleteKey,
+      ]);
+    } else {
+      await deleteKey;
+    }
 
     return Response.json({ success: true });
   } catch (error) {

--- a/app/api/user/api-keys/route.ts
+++ b/app/api/user/api-keys/route.ts
@@ -2,6 +2,12 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { encrypt } from "@/lib/encryption";
 
+/** Providers that can be stored, and whether they need a password alongside the login. */
+const PROVIDERS: Record<string, { needsPassword: boolean }> = {
+  dataforseo: { needsPassword: true },
+  bing: { needsPassword: false },
+};
+
 export async function GET() {
   try {
     const session = await auth();
@@ -14,9 +20,10 @@ export async function GET() {
       select: { provider: true, createdAt: true, updatedAt: true },
     });
 
-    const providers: Record<string, { connected: boolean; updatedAt?: string }> = {
-      dataforseo: { connected: false },
-    };
+    const providers: Record<string, { connected: boolean; updatedAt?: string }> =
+      Object.fromEntries(
+        Object.keys(PROVIDERS).map((provider) => [provider, { connected: false }])
+      );
 
     for (const key of keys) {
       providers[key.provider] = {
@@ -45,16 +52,22 @@ export async function POST(req: Request) {
       password?: string;
     };
 
-    if (!body.provider || !body.login || !body.password) {
+    const config = body.provider ? PROVIDERS[body.provider] : undefined;
+    if (!body.provider || !config) {
+      return Response.json({ error: "Unsupported provider" }, { status: 400 });
+    }
+
+    if (!body.login || (config.needsPassword && !body.password)) {
       return Response.json(
         { error: "Missing required fields: provider, login, password" },
         { status: 400 }
       );
     }
 
-    if (body.provider !== "dataforseo") {
-      return Response.json({ error: "Unsupported provider" }, { status: 400 });
-    }
+    // Single-secret providers (Bing) store the key in `encryptedLogin` and
+    // leave the password slot empty rather than growing the schema.
+    const encryptedLogin = encrypt(body.login);
+    const encryptedPassword = encrypt(body.password ?? "");
 
     const saved = await db.apiKey.upsert({
       where: {
@@ -66,13 +79,10 @@ export async function POST(req: Request) {
       create: {
         userId: session.user.id,
         provider: body.provider,
-        encryptedLogin: encrypt(body.login),
-        encryptedPassword: encrypt(body.password),
+        encryptedLogin,
+        encryptedPassword,
       },
-      update: {
-        encryptedLogin: encrypt(body.login),
-        encryptedPassword: encrypt(body.password),
-      },
+      update: { encryptedLogin, encryptedPassword },
     });
 
     return Response.json(

--- a/app/api/user/api-keys/test/route.ts
+++ b/app/api/user/api-keys/test/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { testConnection } from "@/lib/dataforseo/client";
+import { testBingKey } from "@/lib/bing";
 
 export async function POST(req: Request) {
   try {
@@ -8,7 +9,22 @@ export async function POST(req: Request) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = (await req.json()) as { login?: string; password?: string };
+    const body = (await req.json()) as {
+      provider?: string;
+      login?: string;
+      password?: string;
+    };
+    const provider = body.provider ?? "dataforseo";
+
+    // Bing issues one account-wide key, so `login` carries it and there is no
+    // password to check.
+    if (provider === "bing") {
+      if (!body.login) {
+        return Response.json({ error: "Missing API key" }, { status: 400 });
+      }
+      return Response.json({ success: await testBingKey(body.login) });
+    }
+
     if (!body.login || !body.password) {
       return Response.json(
         { error: "Missing login or password" },

--- a/components/settings/api-keys-section.tsx
+++ b/components/settings/api-keys-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { CheckCircle2, XCircle, Loader2, FlaskConical, Save, Trash2 } from "lucide-react";
 
 type ApiKeyStatus = Record<string, { connected: boolean; updatedAt?: string }>;
@@ -11,6 +12,79 @@ export function ApiKeysSection({
   initialStatus: ApiKeyStatus;
 }) {
   const [status, setStatus] = useState<ApiKeyStatus>(initialStatus);
+
+  function markConnected(provider: string, connected: boolean) {
+    setStatus((prev) => ({
+      ...prev,
+      [provider]: connected
+        ? { connected: true, updatedAt: new Date().toISOString() }
+        : { connected: false },
+    }));
+  }
+
+  return (
+    <div className="panel p-5">
+      <h3 className="font-heading text-lg font-semibold text-foreground">
+        External API Keys
+      </h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Connect third-party APIs for advanced SEO data like keyword volume,
+        domain analysis, and backlinks.
+      </p>
+
+      <div className="mt-5 space-y-3">
+        <ProviderCard
+          provider="dataforseo"
+          name="DataForSEO"
+          description="Keyword research, domain analysis, backlink data"
+          loginLabel="Login"
+          loginPlaceholder="your@email.com"
+          passwordLabel="Password"
+          passwordPlaceholder="API password"
+          status={status.dataforseo}
+          onStatusChange={markConnected}
+        />
+
+        <ProviderCard
+          provider="bing"
+          name="Bing Webmaster Tools"
+          description="Bing queries, pages, crawl and index stats (free)"
+          loginLabel="API key"
+          loginPlaceholder="Settings → API Access → Generate API Key"
+          status={status.bing}
+          onStatusChange={markConnected}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One credential card. DataForSEO needs a login/password pair; Bing issues a
+ * single account-wide key, so the password field is simply omitted there.
+ */
+function ProviderCard({
+  provider,
+  name,
+  description,
+  loginLabel,
+  loginPlaceholder,
+  passwordLabel,
+  passwordPlaceholder,
+  status,
+  onStatusChange,
+}: {
+  provider: string;
+  name: string;
+  description: string;
+  loginLabel: string;
+  loginPlaceholder: string;
+  passwordLabel?: string;
+  passwordPlaceholder?: string;
+  status?: { connected: boolean; updatedAt?: string };
+  onStatusChange: (provider: string, connected: boolean) => void;
+}) {
+  const router = useRouter();
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
   const [testing, setTesting] = useState(false);
@@ -19,10 +93,12 @@ export function ApiKeysSection({
   const [testResult, setTestResult] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const isConnected = status.dataforseo?.connected ?? false;
+  const needsPassword = passwordLabel !== undefined;
+  const isConnected = status?.connected ?? false;
+  const complete = login.length > 0 && (!needsPassword || password.length > 0);
 
   async function handleTest() {
-    if (!login || !password) return;
+    if (!complete) return;
     setTesting(true);
     setTestResult(null);
     setError(null);
@@ -31,7 +107,7 @@ export function ApiKeysSection({
       const res = await fetch("/api/user/api-keys/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ login, password }),
+        body: JSON.stringify({ provider, login, password }),
       });
       const data = await res.json();
       setTestResult(data.success === true);
@@ -45,7 +121,7 @@ export function ApiKeysSection({
   }
 
   async function handleSave() {
-    if (!login || !password) return;
+    if (!complete) return;
     setSaving(true);
     setError(null);
 
@@ -53,17 +129,15 @@ export function ApiKeysSection({
       const res = await fetch("/api/user/api-keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: "dataforseo", login, password }),
+        body: JSON.stringify({ provider, login, password }),
       });
 
       if (res.ok) {
-        setStatus((prev) => ({
-          ...prev,
-          dataforseo: { connected: true, updatedAt: new Date().toISOString() },
-        }));
+        onStatusChange(provider, true);
         setLogin("");
         setPassword("");
         setTestResult(null);
+        router.refresh();
       } else {
         const data = await res.json();
         setError(data.error || "Failed to save");
@@ -83,14 +157,12 @@ export function ApiKeysSection({
       const res = await fetch("/api/user/api-keys", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: "dataforseo" }),
+        body: JSON.stringify({ provider }),
       });
 
       if (res.ok) {
-        setStatus((prev) => ({
-          ...prev,
-          dataforseo: { connected: false },
-        }));
+        onStatusChange(provider, false);
+        router.refresh();
       }
     } catch {
       setError("Delete failed");
@@ -100,129 +172,118 @@ export function ApiKeysSection({
   }
 
   return (
-    <div className="panel p-5">
-      <h3 className="font-heading text-lg font-semibold text-foreground">
-        External API Keys
-      </h3>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Connect third-party APIs for advanced SEO data like keyword volume,
-        domain analysis, and backlinks.
-      </p>
-
-      <div className="mt-5 rounded-lg border border-border bg-card p-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h4 className="font-medium text-foreground">DataForSEO</h4>
-            <p className="text-xs text-muted-foreground">
-              Keyword research, domain analysis, backlink data
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {isConnected ? (
-              <span className="flex items-center gap-1.5 rounded-full bg-signal/10 px-2.5 py-1 text-xs font-medium text-signal">
-                <CheckCircle2 className="size-3.5" />
-                Connected
-              </span>
-            ) : (
-              <span className="flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
-                <XCircle className="size-3.5" />
-                Not configured
-              </span>
-            )}
-          </div>
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h4 className="font-medium text-foreground">{name}</h4>
+          <p className="text-xs text-muted-foreground">{description}</p>
         </div>
+        <div className="flex items-center gap-2">
+          {isConnected ? (
+            <span className="flex items-center gap-1.5 rounded-full bg-signal/10 px-2.5 py-1 text-xs font-medium text-signal">
+              <CheckCircle2 className="size-3.5" />
+              Connected
+            </span>
+          ) : (
+            <span className="flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+              <XCircle className="size-3.5" />
+              Not configured
+            </span>
+          )}
+        </div>
+      </div>
 
-        {isConnected ? (
-          <div className="mt-4 flex items-center justify-between">
-            <p className="text-xs text-muted-foreground">
-              Last updated:{" "}
-              {status.dataforseo.updatedAt
-                ? new Date(status.dataforseo.updatedAt).toLocaleDateString()
-                : "—"}
-            </p>
-            <button
-              type="button"
-              onClick={handleDelete}
-              disabled={deleting}
-              className="flex items-center gap-1.5 rounded-lg border border-danger/30 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/10 disabled:opacity-50"
-            >
-              {deleting ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Trash2 className="size-3" />
-              )}
-              Remove
-            </button>
+      {isConnected ? (
+        <div className="mt-4 flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Last updated:{" "}
+            {status?.updatedAt
+              ? new Date(status.updatedAt).toLocaleDateString()
+              : "—"}
+          </p>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="flex items-center gap-1.5 rounded-lg border border-danger/30 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/10 disabled:opacity-50"
+          >
+            {deleting ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <Trash2 className="size-3" />
+            )}
+            Remove
+          </button>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              {loginLabel}
+            </label>
+            <input
+              type={needsPassword ? "text" : "password"}
+              value={login}
+              onChange={(e) => setLogin(e.target.value)}
+              placeholder={loginPlaceholder}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
           </div>
-        ) : (
-          <div className="mt-4 space-y-3">
+
+          {needsPassword && (
             <div>
               <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                Login
-              </label>
-              <input
-                type="text"
-                value={login}
-                onChange={(e) => setLogin(e.target.value)}
-                placeholder="your@email.com"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                Password
+                {passwordLabel}
               </label>
               <input
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="API password"
+                placeholder={passwordPlaceholder}
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               />
             </div>
+          )}
 
-            {error && (
-              <p className="text-xs text-danger">{error}</p>
-            )}
+          {error && <p className="text-xs text-danger">{error}</p>}
 
-            {testResult === true && (
-              <p className="flex items-center gap-1.5 text-xs text-signal">
-                <CheckCircle2 className="size-3.5" />
-                Connection successful
-              </p>
-            )}
+          {testResult === true && (
+            <p className="flex items-center gap-1.5 text-xs text-signal">
+              <CheckCircle2 className="size-3.5" />
+              Connection successful
+            </p>
+          )}
 
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={handleTest}
-                disabled={!login || !password || testing}
-                className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-muted disabled:opacity-50"
-              >
-                {testing ? (
-                  <Loader2 className="size-3 animate-spin" />
-                ) : (
-                  <FlaskConical className="size-3" />
-                )}
-                Test Connection
-              </button>
-              <button
-                type="button"
-                onClick={handleSave}
-                disabled={!login || !password || saving}
-                className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
-              >
-                {saving ? (
-                  <Loader2 className="size-3 animate-spin" />
-                ) : (
-                  <Save className="size-3" />
-                )}
-                Save Key
-              </button>
-            </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleTest}
+              disabled={!complete || testing}
+              className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-muted disabled:opacity-50"
+            >
+              {testing ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <FlaskConical className="size-3" />
+              )}
+              Test Connection
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!complete || saving}
+              className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saving ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Save className="size-3" />
+              )}
+              Save Key
+            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/settings/bing-site-section.tsx
+++ b/components/settings/bing-site-section.tsx
@@ -13,7 +13,6 @@ import {
 
 interface BingSite {
   url: string;
-  isVerified: boolean;
 }
 
 export function BingSiteSection({
@@ -35,7 +34,6 @@ export function BingSiteSection({
   const [error, setError] = useState<string | null>(null);
 
   async function loadSites() {
-    if (sites.length > 0) return;
     setLoading(true);
     setError(null);
 
@@ -95,6 +93,11 @@ export function BingSiteSection({
         `Synced ${data.daysUpserted} days, ${data.queriesUpserted} query weeks, ` +
           `${data.pagesUpserted} page weeks.`
       );
+      if (data.partial?.length) {
+        setError(
+          `Bing did not answer for: ${data.partial.join(", ")}. Run the sync again.`
+        );
+      }
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Sync failed");
@@ -159,7 +162,7 @@ export function BingSiteSection({
             <button
               type="button"
               onClick={handleSave}
-              disabled={!selected || selected === bingSite || saving}
+              disabled={!selected || selected === bingSite || saving || syncing}
               className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
             >
               {saving ? (

--- a/components/settings/bing-site-section.tsx
+++ b/components/settings/bing-site-section.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, Loader2, RefreshCw, Save, XCircle } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface BingSite {
+  url: string;
+  isVerified: boolean;
+}
+
+export function BingSiteSection({
+  siteId,
+  bingSite,
+  keyConnected,
+}: {
+  siteId: string;
+  bingSite: string | null;
+  keyConnected: boolean;
+}) {
+  const router = useRouter();
+  const [sites, setSites] = useState<BingSite[]>([]);
+  const [selected, setSelected] = useState(bingSite ?? "");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadSites() {
+    if (sites.length > 0) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/bing/sites");
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to load Bing sites");
+      setSites(data as BingSite[]);
+      if (!data.length) setError("This Bing account has no verified sites.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load Bing sites");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const res = await fetch(`/api/sites/${siteId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bingSite: selected }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save");
+      }
+      setMessage("Bing property connected.");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSync() {
+    setSyncing(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const res = await fetch("/api/bing/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ siteId }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.success === false) {
+        throw new Error(data.error || "Sync failed");
+      }
+      setMessage(
+        `Synced ${data.daysUpserted} days, ${data.queriesUpserted} query weeks, ` +
+          `${data.pagesUpserted} page weeks.`
+      );
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <div className="panel p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="font-heading text-lg font-semibold text-foreground">
+            Bing Webmaster property
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Bing reports its own queries, pages and crawl stats. The property URL
+            often differs from the Search Console one, so pick it explicitly.
+          </p>
+        </div>
+        {bingSite ? (
+          <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-signal/10 px-2.5 py-1 text-xs font-medium text-signal">
+            <CheckCircle2 className="size-3.5" />
+            Connected
+          </span>
+        ) : (
+          <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            <XCircle className="size-3.5" />
+            Not connected
+          </span>
+        )}
+      </div>
+
+      {!keyConnected ? (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Add a Bing Webmaster Tools API key above first.
+        </p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={selected}
+              onValueChange={(value) => setSelected(String(value))}
+              onOpenChange={(open) => {
+                if (open) void loadSites();
+              }}
+            >
+              <SelectTrigger className="min-w-64">
+                <SelectValue
+                  placeholder={loading ? "Loading…" : "Choose a Bing property"}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {sites.map((site) => (
+                  <SelectItem key={site.url} value={site.url}>
+                    {site.url}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!selected || selected === bingSite || saving}
+              className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saving ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Save className="size-3" />
+              )}
+              Save
+            </button>
+
+            <button
+              type="button"
+              onClick={handleSync}
+              disabled={!bingSite || syncing}
+              className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-muted disabled:opacity-50"
+            >
+              {syncing ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+              Sync Bing
+            </button>
+          </div>
+
+          {message && <p className="text-xs text-signal">{message}</p>}
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/bing/bing-client.ts
+++ b/lib/bing/bing-client.ts
@@ -1,0 +1,191 @@
+import { db } from "@/lib/db";
+import { decrypt } from "@/lib/encryption";
+import {
+  aggregateWeekly,
+  parseBingDate,
+  type BingSearchWeek,
+  type RawQueryStats,
+} from "./bing-parse";
+
+const BING_API_BASE = "https://ssl.bing.com/webmaster/api.svc/json";
+
+export class BingKeyMissingError extends Error {
+  constructor() {
+    super("No Bing Webmaster Tools API key configured. Add one in Settings.");
+    this.name = "BingKeyMissingError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BingSite {
+  url: string;
+  isVerified: boolean;
+}
+
+export interface BingTrafficDay {
+  date: string; // YYYY-MM-DD
+  clicks: number;
+  impressions: number;
+}
+
+export interface BingCrawlDay {
+  date: string;
+  crawledPages: number;
+  inIndex: number;
+  inLinks: number;
+  code2xx: number;
+  code301: number;
+  code302: number;
+  code4xx: number;
+  code5xx: number;
+  blockedByRobots: number;
+  crawlErrors: number;
+}
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+/**
+ * The Bing key is issued per Bing Webmaster account, not per site, which is
+ * exactly the grain of the ApiKey table. It is stored in `encryptedLogin`;
+ * `encryptedPassword` is unused (the model was shaped for DataForSEO's pair).
+ */
+async function getBingApiKey(userId: string): Promise<string> {
+  const apiKey = await db.apiKey.findUnique({
+    where: { userId_provider: { userId, provider: "bing" } },
+  });
+  if (!apiKey) throw new BingKeyMissingError();
+  return decrypt(apiKey.encryptedLogin);
+}
+
+// ---------------------------------------------------------------------------
+// Base request
+// ---------------------------------------------------------------------------
+
+/**
+ * Bing accepts no date range, so every call returns the full history and a
+ * slow endpoint has no smaller version to fall back to. Without a deadline one
+ * hung request holds the whole sync open until the platform kills it.
+ */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+async function bingGet<T>(
+  apiKey: string,
+  method: string,
+  params: Record<string, string> = {}
+): Promise<T> {
+  const query = new URLSearchParams({ ...params, apikey: apiKey });
+  const response = await fetch(`${BING_API_BASE}/${method}?${query}`, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = await response.text();
+
+  if (!response.ok) {
+    let detail = body.slice(0, 300);
+    try {
+      const parsed = JSON.parse(body) as { ErrorCode?: number; Message?: string };
+      if (parsed.ErrorCode !== undefined) {
+        detail = `ErrorCode ${parsed.ErrorCode}${
+          parsed.Message ? ` - ${parsed.Message}` : ""
+        }`;
+      }
+    } catch {
+      // fall back to the raw body
+    }
+    throw new Error(`Bing ${method} failed: ${response.status} ${detail}`);
+  }
+
+  return (JSON.parse(body) as { d: T }).d;
+}
+
+// ---------------------------------------------------------------------------
+// Endpoints
+// ---------------------------------------------------------------------------
+
+/** Every verified site on the account this key belongs to. */
+export async function listBingSites(userId: string): Promise<BingSite[]> {
+  const apiKey = await getBingApiKey(userId);
+  const sites = await bingGet<Array<{ Url: string; IsVerified?: boolean }>>(
+    apiKey,
+    "GetUserSites"
+  );
+  return (sites ?? []).map((site) => ({
+    url: site.Url,
+    isVerified: site.IsVerified ?? true,
+  }));
+}
+
+/** Free and site-independent, which makes it the natural connection test. */
+export async function testBingKey(apiKey: string): Promise<boolean> {
+  try {
+    await bingGet<unknown[]>(apiKey, "GetUserSites");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Site clicks/impressions, one row per calendar day (~16 months of history). */
+export async function fetchBingTraffic(
+  userId: string,
+  siteUrl: string
+): Promise<BingTrafficDay[]> {
+  const apiKey = await getBingApiKey(userId);
+  const rows = await bingGet<
+    Array<{ Date: string; Clicks: number; Impressions: number }>
+  >(apiKey, "GetRankAndTrafficStats", { siteUrl });
+  return (rows ?? []).map((row) => ({
+    date: parseBingDate(row.Date),
+    clicks: row.Clicks ?? 0,
+    impressions: row.Impressions ?? 0,
+  }));
+}
+
+/**
+ * Query or page performance. Bing returns WEEKLY buckets (week ending Friday)
+ * and accepts no date parameters at all - every call returns the full history.
+ */
+export async function fetchBingSearchStats(
+  userId: string,
+  siteUrl: string,
+  kind: "query" | "page"
+): Promise<BingSearchWeek[]> {
+  const apiKey = await getBingApiKey(userId);
+  const rows = await bingGet<RawQueryStats[]>(
+    apiKey,
+    kind === "query" ? "GetQueryStats" : "GetPageStats",
+    { siteUrl }
+  );
+  return aggregateWeekly(rows ?? []);
+}
+
+/** Bing's own crawler stats, one row per day. Google exposes no equivalent API. */
+export async function fetchBingCrawlStats(
+  userId: string,
+  siteUrl: string
+): Promise<BingCrawlDay[]> {
+  const apiKey = await getBingApiKey(userId);
+  const rows = await bingGet<Array<Record<string, number | string>>>(
+    apiKey,
+    "GetCrawlStats",
+    { siteUrl }
+  );
+
+  return (rows ?? []).map((row) => ({
+    date: parseBingDate(String(row.Date)),
+    crawledPages: Number(row.CrawledPages ?? 0),
+    inIndex: Number(row.InIndex ?? 0),
+    inLinks: Number(row.InLinks ?? 0),
+    code2xx: Number(row.Code2xx ?? 0),
+    code301: Number(row.Code301 ?? 0),
+    code302: Number(row.Code302 ?? 0),
+    code4xx: Number(row.Code4xx ?? 0),
+    code5xx: Number(row.Code5xx ?? 0),
+    blockedByRobots: Number(row.BlockedByRobotsTxt ?? 0),
+    crawlErrors: Number(row.CrawlErrors ?? 0),
+  }));
+}

--- a/lib/bing/bing-client.ts
+++ b/lib/bing/bing-client.ts
@@ -54,7 +54,7 @@ export interface BingCrawlDay {
  * exactly the grain of the ApiKey table. It is stored in `encryptedLogin`;
  * `encryptedPassword` is unused (the model was shaped for DataForSEO's pair).
  */
-async function getBingApiKey(userId: string): Promise<string> {
+export async function getBingApiKey(userId: string): Promise<string> {
   const apiKey = await db.apiKey.findUnique({
     where: { userId_provider: { userId, provider: "bing" } },
   });

--- a/lib/bing/bing-client.ts
+++ b/lib/bing/bing-client.ts
@@ -22,7 +22,6 @@ export class BingKeyMissingError extends Error {
 
 export interface BingSite {
   url: string;
-  isVerified: boolean;
 }
 
 export interface BingTrafficDay {
@@ -113,10 +112,10 @@ export async function listBingSites(userId: string): Promise<BingSite[]> {
     apiKey,
     "GetUserSites"
   );
-  return (sites ?? []).map((site) => ({
-    url: site.Url,
-    isVerified: site.IsVerified ?? true,
-  }));
+  // Only verified properties answer the stats endpoints.
+  return (sites ?? [])
+    .filter((site) => site.IsVerified ?? true)
+    .map((site) => ({ url: site.Url }));
 }
 
 /** Free and site-independent, which makes it the natural connection test. */
@@ -131,10 +130,9 @@ export async function testBingKey(apiKey: string): Promise<boolean> {
 
 /** Site clicks/impressions, one row per calendar day (~16 months of history). */
 export async function fetchBingTraffic(
-  userId: string,
+  apiKey: string,
   siteUrl: string
 ): Promise<BingTrafficDay[]> {
-  const apiKey = await getBingApiKey(userId);
   const rows = await bingGet<
     Array<{ Date: string; Clicks: number; Impressions: number }>
   >(apiKey, "GetRankAndTrafficStats", { siteUrl });
@@ -150,11 +148,10 @@ export async function fetchBingTraffic(
  * and accepts no date parameters at all - every call returns the full history.
  */
 export async function fetchBingSearchStats(
-  userId: string,
+  apiKey: string,
   siteUrl: string,
   kind: "query" | "page"
 ): Promise<BingSearchWeek[]> {
-  const apiKey = await getBingApiKey(userId);
   const rows = await bingGet<RawQueryStats[]>(
     apiKey,
     kind === "query" ? "GetQueryStats" : "GetPageStats",
@@ -165,10 +162,9 @@ export async function fetchBingSearchStats(
 
 /** Bing's own crawler stats, one row per day. Google exposes no equivalent API. */
 export async function fetchBingCrawlStats(
-  userId: string,
+  apiKey: string,
   siteUrl: string
 ): Promise<BingCrawlDay[]> {
-  const apiKey = await getBingApiKey(userId);
   const rows = await bingGet<Array<Record<string, number | string>>>(
     apiKey,
     "GetCrawlStats",

--- a/lib/bing/bing-parse.test.ts
+++ b/lib/bing/bing-parse.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateWeekly,
+  collapseWeeks,
+  normalisePosition,
+  parseBingDate,
+} from "./bing-parse";
+
+describe("parseBingDate", () => {
+  // Samples taken from live GetQueryStats/GetCrawlStats responses.
+  it("keeps the day Bing means across both DST offsets", () => {
+    expect(parseBingDate("/Date(1747983600000-0700)/")).toBe("2025-05-23");
+    expect(parseBingDate("/Date(1772179200000-0800)/")).toBe("2026-02-27");
+  });
+
+  it("lands on Friday, the day Bing closes a weekly bucket", () => {
+    const day = new Date(`${parseBingDate("/Date(1786690800000-0700)/")}T00:00:00Z`);
+    expect(day.getUTCDay()).toBe(5);
+  });
+
+  it("rejects anything it cannot read instead of inventing a date", () => {
+    expect(() => parseBingDate("2026-08-21")).toThrow();
+  });
+});
+
+describe("normalisePosition", () => {
+  it("treats -1 as the no-clicks sentinel, not as a rank", () => {
+    expect(normalisePosition(-1)).toBeNull();
+    expect(normalisePosition(0)).toBeNull();
+    expect(normalisePosition(4)).toBe(4);
+  });
+});
+
+describe("aggregateWeekly", () => {
+  it("sums repeats of one key inside a bucket instead of overwriting them", () => {
+    const rows = aggregateWeekly([
+      {
+        Query: "blue widgets",
+        Date: "/Date(1747983600000-0700)/",
+        Clicks: 1,
+        Impressions: 10,
+        AvgImpressionPosition: 2,
+      },
+      {
+        Query: "blue widgets",
+        Date: "/Date(1747983600000-0700)/",
+        Clicks: 2,
+        Impressions: 30,
+        AvgImpressionPosition: 6,
+      },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].clicks).toBe(3);
+    expect(rows[0].impressions).toBe(40);
+    // Impression-weighted: (2*10 + 6*30) / 40 = 5
+    expect(rows[0].avgImpressionPosition).toBe(5);
+  });
+
+  it("keeps separate weeks separate", () => {
+    const rows = aggregateWeekly([
+      {
+        Query: "widget repair",
+        Date: "/Date(1747983600000-0700)/",
+        Clicks: 0,
+        Impressions: 3,
+        AvgImpressionPosition: 8,
+      },
+      {
+        Query: "widget repair",
+        Date: "/Date(1786690800000-0700)/",
+        Clicks: 0,
+        Impressions: 5,
+        AvgImpressionPosition: 4,
+      },
+    ]);
+
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe("collapseWeeks", () => {
+  it("adds volume across weeks and weights position by impressions", () => {
+    const [row] = collapseWeeks([
+      {
+        key: "widget store near me",
+        weekEnding: "2026-08-14",
+        clicks: 1,
+        impressions: 10,
+        avgImpressionPosition: 1,
+      },
+      {
+        key: "widget store near me",
+        weekEnding: "2026-08-21",
+        clicks: 3,
+        impressions: 30,
+        avgImpressionPosition: 5,
+      },
+    ]);
+
+    expect(row.clicks).toBe(4);
+    expect(row.impressions).toBe(40);
+    expect(row.position).toBe(4); // (1*10 + 5*30) / 40
+    expect(row.ctr).toBeCloseTo(0.1);
+  });
+
+  it("reports no position when every bucket was a sentinel", () => {
+    const [row] = collapseWeeks([
+      {
+        key: "widgets",
+        weekEnding: "2026-08-21",
+        clicks: 0,
+        impressions: 7,
+        avgImpressionPosition: null,
+      },
+    ]);
+
+    expect(row.position).toBeNull();
+    expect(row.ctr).toBe(0);
+  });
+});

--- a/lib/bing/bing-parse.ts
+++ b/lib/bing/bing-parse.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure parsing helpers for the Bing Webmaster Tools JSON API.
+ * Kept free of database imports so they can be unit tested on their own.
+ */
+
+/**
+ * One weekly bucket for a query or a page. Bing reports both through the same
+ * QueryStats contract - for GetPageStats the URL arrives in the `Query` field.
+ */
+export interface BingSearchWeek {
+  key: string;
+  weekEnding: string; // YYYY-MM-DD (a Friday)
+  clicks: number;
+  impressions: number;
+  avgImpressionPosition: number | null;
+}
+
+export interface RawQueryStats {
+  Query: string;
+  Date: string;
+  Clicks: number;
+  Impressions: number;
+  AvgImpressionPosition?: number;
+}
+
+/**
+ * Bing serialises dates as .NET strings: `/Date(1747983600000-0700)/`.
+ *
+ * The epoch is midnight in the trailing offset's timezone, so the offset has
+ * to be added back before formatting. Bing's own offsets are negative, where
+ * reading the epoch as UTC happens to land on the right day anyway - but a
+ * positive offset puts local midnight before UTC midnight and would report
+ * the previous day, shifting every weekly bucket by one.
+ */
+export function parseBingDate(value: string): string {
+  const match = /\/Date\((-?\d+)([+-]\d{4})?\)/.exec(value);
+  if (!match) throw new Error(`Unparseable Bing date: ${value}`);
+
+  const offsetMinutes = match[2]
+    ? (match[2][0] === "-" ? -1 : 1) *
+      (Number(match[2].slice(1, 3)) * 60 + Number(match[2].slice(3)))
+    : 0;
+
+  return new Date(Number(match[1]) + offsetMinutes * 60_000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+/**
+ * Bing sends -1 for AvgClickPosition when the row had no clicks at all.
+ * That is a sentinel, not a position - averaging it produces negative ranks.
+ */
+export function normalisePosition(value: unknown): number | null {
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+/**
+ * Collapses raw rows to one record per (key, week), summing volume and
+ * weighting positions by impressions. Bing can repeat a key inside a bucket;
+ * writing rows straight through would let the last one overwrite the rest.
+ */
+export function aggregateWeekly(rows: RawQueryStats[]): BingSearchWeek[] {
+  const byKey = new Map<
+    string,
+    BingSearchWeek & { impWeight: number }
+  >();
+
+  for (const row of rows) {
+    if (!row?.Query || !row?.Date) continue;
+    const weekEnding = parseBingDate(row.Date);
+    const id = `${row.Query} ${weekEnding}`;
+    const clicks = row.Clicks ?? 0;
+    const impressions = row.Impressions ?? 0;
+    const impPos = normalisePosition(row.AvgImpressionPosition);
+
+    const entry = byKey.get(id) ?? {
+      key: row.Query,
+      weekEnding,
+      clicks: 0,
+      impressions: 0,
+      avgImpressionPosition: null,
+      impWeight: 0,
+    };
+
+    entry.clicks += clicks;
+    entry.impressions += impressions;
+    if (impPos !== null) {
+      const weight = Math.max(impressions, 1);
+      entry.avgImpressionPosition =
+        (entry.avgImpressionPosition ?? 0) + impPos * weight;
+      entry.impWeight += weight;
+    }
+
+    byKey.set(id, entry);
+  }
+
+  return Array.from(byKey.values()).map((entry) => ({
+    key: entry.key,
+    weekEnding: entry.weekEnding,
+    clicks: entry.clicks,
+    impressions: entry.impressions,
+    avgImpressionPosition:
+      entry.avgImpressionPosition !== null && entry.impWeight > 0
+        ? Number((entry.avgImpressionPosition / entry.impWeight).toFixed(2))
+        : null,
+  }));
+}
+
+/**
+ * Weekly buckets that fall inside a day-based window, collapsed per key.
+ * A bucket counts when its week-ending date is inside the window, so the
+ * edges are approximate by up to six days - Bing offers no finer grain.
+ */
+export function collapseWeeks(
+  rows: BingSearchWeek[]
+): Array<{
+  key: string;
+  clicks: number;
+  impressions: number;
+  position: number | null;
+  ctr: number;
+}> {
+  const byKey = new Map<
+    string,
+    { clicks: number; impressions: number; weighted: number; weight: number }
+  >();
+
+  for (const row of rows) {
+    const entry = byKey.get(row.key) ?? {
+      clicks: 0,
+      impressions: 0,
+      weighted: 0,
+      weight: 0,
+    };
+    entry.clicks += row.clicks;
+    entry.impressions += row.impressions;
+    if (row.avgImpressionPosition !== null) {
+      const weight = Math.max(row.impressions, 1);
+      entry.weighted += row.avgImpressionPosition * weight;
+      entry.weight += weight;
+    }
+    byKey.set(row.key, entry);
+  }
+
+  return Array.from(byKey.entries())
+    .map(([key, entry]) => ({
+      key,
+      clicks: entry.clicks,
+      impressions: entry.impressions,
+      position:
+        entry.weight > 0 ? Number((entry.weighted / entry.weight).toFixed(1)) : null,
+      ctr: entry.impressions > 0 ? entry.clicks / entry.impressions : 0,
+    }))
+    .sort((a, b) => b.clicks - a.clicks || b.impressions - a.impressions);
+}

--- a/lib/bing/index.ts
+++ b/lib/bing/index.ts
@@ -1,0 +1,2 @@
+export * from "./bing-parse";
+export * from "./bing-client";

--- a/lib/workers/bing-sync.test.ts
+++ b/lib/workers/bing-sync.test.ts
@@ -1,23 +1,47 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { encrypt } from "@/lib/encryption";
 
-// With no key stored, every Bing endpoint would reject and the caller used to
-// see "every Bing endpoint failed" instead of being told to add a key.
+const db = vi.hoisted(() => ({
+  site: { findUnique: vi.fn() },
+  apiKey: { findUnique: vi.fn() },
+  bingDaily: { upsert: vi.fn(async () => ({})) },
+  bingSearchWeekly: { upsert: vi.fn(async () => ({})) },
+}));
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    site: {
-      findUnique: async () => ({ userId: "user-1", bingSite: "https://a.example/" }),
-    },
-    apiKey: { findUnique: async () => null },
-  },
+vi.mock("@/lib/db", () => ({ db }));
+// The fetchers are the network; the key lookup stays real.
+vi.mock("@/lib/bing", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/bing")>()),
+  fetchBingTraffic: async () => [{ date: "2026-08-01", clicks: 1, impressions: 2 }],
+  fetchBingSearchStats: async () => [],
+  fetchBingCrawlStats: async () => [],
 }));
 
 import { syncBingDataForSite } from "./bing-sync";
 
+const site = { userId: "user-1", bingSite: "https://a.example/" };
+
+beforeAll(() => {
+  process.env.NEXTAUTH_SECRET = "test-secret-for-vitest-only";
+});
+
 describe("syncBingDataForSite", () => {
   it("names the missing key instead of a generic endpoint failure", async () => {
+    db.site.findUnique.mockResolvedValue(site);
+    db.apiKey.findUnique.mockResolvedValue(null);
     const result = await syncBingDataForSite("user-1", "site-a");
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/API key/);
+  });
+
+  it("writes nothing when the property changed while the fetches ran", async () => {
+    db.apiKey.findUnique.mockResolvedValue({ encryptedLogin: encrypt("key") });
+    db.site.findUnique
+      .mockResolvedValueOnce(site)
+      .mockResolvedValueOnce({ bingSite: "https://b.example/" });
+    const result = await syncBingDataForSite("user-1", "site-a");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/changed/);
+    expect(db.bingDaily.upsert).not.toHaveBeenCalled();
   });
 });

--- a/lib/workers/bing-sync.test.ts
+++ b/lib/workers/bing-sync.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+// With no key stored, every Bing endpoint would reject and the caller used to
+// see "every Bing endpoint failed" instead of being told to add a key.
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    site: {
+      findUnique: async () => ({ userId: "user-1", bingSite: "https://a.example/" }),
+    },
+    apiKey: { findUnique: async () => null },
+  },
+}));
+
+import { syncBingDataForSite } from "./bing-sync";
+
+describe("syncBingDataForSite", () => {
+  it("names the missing key instead of a generic endpoint failure", async () => {
+    const result = await syncBingDataForSite("user-1", "site-a");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/API key/);
+  });
+});

--- a/lib/workers/bing-sync.ts
+++ b/lib/workers/bing-sync.ts
@@ -3,6 +3,7 @@ import {
   fetchBingCrawlStats,
   fetchBingSearchStats,
   fetchBingTraffic,
+  getBingApiKey,
 } from "@/lib/bing";
 
 export interface BingSyncResult {
@@ -71,6 +72,11 @@ export async function syncBingDataForSite(
     if (!site.bingSite) {
       throw new Error("Site does not have a Bing Webmaster property connected");
     }
+
+    // Resolve the key once up front: with no key every endpoint below would
+    // reject and the caller would see "every Bing endpoint failed" instead of
+    // "add a key in Settings".
+    await getBingApiKey(userId);
 
     // Four independent endpoints. Losing one should not throw away the three
     // that answered: there is no date parameter, so a retry re-downloads the

--- a/lib/workers/bing-sync.ts
+++ b/lib/workers/bing-sync.ts
@@ -73,19 +73,18 @@ export async function syncBingDataForSite(
       throw new Error("Site does not have a Bing Webmaster property connected");
     }
 
-    // Resolve the key once up front: with no key every endpoint below would
-    // reject and the caller would see "every Bing endpoint failed" instead of
-    // "add a key in Settings".
-    await getBingApiKey(userId);
+    // Resolved once: with no key every endpoint below would reject and the
+    // caller would see "every Bing endpoint failed" instead of "add a key".
+    const apiKey = await getBingApiKey(userId);
 
     // Four independent endpoints. Losing one should not throw away the three
     // that answered: there is no date parameter, so a retry re-downloads the
     // whole history again.
     const settled = await Promise.allSettled([
-      fetchBingTraffic(userId, site.bingSite),
-      fetchBingSearchStats(userId, site.bingSite, "query"),
-      fetchBingSearchStats(userId, site.bingSite, "page"),
-      fetchBingCrawlStats(userId, site.bingSite),
+      fetchBingTraffic(apiKey, site.bingSite),
+      fetchBingSearchStats(apiKey, site.bingSite, "query"),
+      fetchBingSearchStats(apiKey, site.bingSite, "page"),
+      fetchBingCrawlStats(apiKey, site.bingSite),
     ]);
     const [traffic, queries, pages, crawl] = settled.map((result) =>
       result.status === "fulfilled" ? result.value : []
@@ -104,6 +103,17 @@ export async function syncBingDataForSite(
       .filter((name): name is string => name !== null);
     if (failed.length === settled.length) {
       throw new Error(`every Bing endpoint failed (${failed.join(", ")})`);
+    }
+
+    // The rows are keyed by site, not property. If the property was changed
+    // while the fetches ran, writing these would blend two properties' history
+    // under the new one right after the change wiped the old rows.
+    const current = await db.site.findUnique({
+      where: { id: siteId },
+      select: { bingSite: true },
+    });
+    if (current?.bingSite !== site.bingSite) {
+      throw new Error("Bing property changed during the sync; nothing written");
     }
 
     console.log(

--- a/lib/workers/bing-sync.ts
+++ b/lib/workers/bing-sync.ts
@@ -1,0 +1,187 @@
+import { db } from "@/lib/db";
+import {
+  fetchBingCrawlStats,
+  fetchBingSearchStats,
+  fetchBingTraffic,
+} from "@/lib/bing";
+
+export interface BingSyncResult {
+  success: boolean;
+  daysUpserted: number;
+  queriesUpserted: number;
+  pagesUpserted: number;
+  error?: string;
+  /** Endpoints that failed while the others were written. */
+  partial?: string[];
+}
+
+type DailyRow = {
+  clicks?: number;
+  impressions?: number;
+  crawledPages?: number;
+  inIndex?: number;
+  inLinks?: number;
+  code2xx?: number;
+  code301?: number;
+  code302?: number;
+  code4xx?: number;
+  code5xx?: number;
+  blockedByRobots?: number;
+  crawlErrors?: number;
+};
+
+function utcDay(date: string): Date {
+  return new Date(`${date}T00:00:00.000Z`);
+}
+
+/** Prisma has no upsertMany; small batches keep the round trips off the clock. */
+async function inChunks<T>(
+  items: T[],
+  size: number,
+  run: (item: T) => Promise<unknown>
+): Promise<void> {
+  for (let i = 0; i < items.length; i += size) {
+    await Promise.all(items.slice(i, i + size).map(run));
+  }
+}
+
+/**
+ * Pulls everything Bing has for one site and upserts it.
+ *
+ * No endpoint accepts a date range, so every sync is a full refresh: Bing
+ * returns its whole history each time and the upserts make that idempotent.
+ * That also means there is no backfill script to write, unlike GSC.
+ */
+export async function syncBingDataForSite(
+  userId: string,
+  siteId: string
+): Promise<BingSyncResult> {
+  const empty = { daysUpserted: 0, queriesUpserted: 0, pagesUpserted: 0 };
+
+  try {
+    const site = await db.site.findUnique({
+      where: { id: siteId },
+      select: { userId: true, bingSite: true },
+    });
+
+    if (!site) throw new Error("Site not found");
+    if (site.userId !== userId) {
+      throw new Error("Unauthorized: Site does not belong to user");
+    }
+    if (!site.bingSite) {
+      throw new Error("Site does not have a Bing Webmaster property connected");
+    }
+
+    // Four independent endpoints. Losing one should not throw away the three
+    // that answered: there is no date parameter, so a retry re-downloads the
+    // whole history again.
+    const settled = await Promise.allSettled([
+      fetchBingTraffic(userId, site.bingSite),
+      fetchBingSearchStats(userId, site.bingSite, "query"),
+      fetchBingSearchStats(userId, site.bingSite, "page"),
+      fetchBingCrawlStats(userId, site.bingSite),
+    ]);
+    const [traffic, queries, pages, crawl] = settled.map((result) =>
+      result.status === "fulfilled" ? result.value : []
+    ) as [
+      Awaited<ReturnType<typeof fetchBingTraffic>>,
+      Awaited<ReturnType<typeof fetchBingSearchStats>>,
+      Awaited<ReturnType<typeof fetchBingSearchStats>>,
+      Awaited<ReturnType<typeof fetchBingCrawlStats>>,
+    ];
+    const failed = settled
+      .map((result, index) =>
+        result.status === "rejected"
+          ? ["traffic", "queries", "pages", "crawl"][index]
+          : null
+      )
+      .filter((name): name is string => name !== null);
+    if (failed.length === settled.length) {
+      throw new Error(`every Bing endpoint failed (${failed.join(", ")})`);
+    }
+
+    console.log(
+      `[Bing Sync] ${site.bingSite}: ${traffic.length} traffic days, ` +
+        `${queries.length} query weeks, ${pages.length} page weeks, ` +
+        `${crawl.length} crawl days`
+    );
+
+    // Traffic and crawl stats are both keyed by (site, day), so they share a row.
+    const daily = new Map<string, DailyRow>();
+    for (const day of traffic) {
+      daily.set(day.date, {
+        ...daily.get(day.date),
+        clicks: day.clicks,
+        impressions: day.impressions,
+      });
+    }
+    for (const day of crawl) {
+      daily.set(day.date, {
+        ...daily.get(day.date),
+        crawledPages: day.crawledPages,
+        inIndex: day.inIndex,
+        inLinks: day.inLinks,
+        code2xx: day.code2xx,
+        code301: day.code301,
+        code302: day.code302,
+        code4xx: day.code4xx,
+        code5xx: day.code5xx,
+        blockedByRobots: day.blockedByRobots,
+        crawlErrors: day.crawlErrors,
+      });
+    }
+
+    let daysUpserted = 0;
+    await inChunks(Array.from(daily.entries()), 25, async ([date, values]) => {
+      await db.bingDaily.upsert({
+        where: { siteId_date: { siteId, date: utcDay(date) } },
+        create: { siteId, date: utcDay(date), ...values },
+        update: values,
+      });
+      daysUpserted++;
+    });
+
+    const counts = { query: 0, page: 0 };
+    for (const kind of ["query", "page"] as const) {
+      const rows = kind === "query" ? queries : pages;
+      await inChunks(rows, 25, async (row) => {
+        const values = {
+          clicks: row.clicks,
+          impressions: row.impressions,
+          avgImpressionPosition: row.avgImpressionPosition,
+        };
+        await db.bingSearchWeekly.upsert({
+          where: {
+            siteId_kind_key_weekEnding: {
+              siteId,
+              kind,
+              key: row.key,
+              weekEnding: utcDay(row.weekEnding),
+            },
+          },
+          create: {
+            siteId,
+            kind,
+            key: row.key,
+            weekEnding: utcDay(row.weekEnding),
+            ...values,
+          },
+          update: values,
+        });
+        counts[kind]++;
+      });
+    }
+
+    return {
+      success: true,
+      daysUpserted,
+      queriesUpserted: counts.query,
+      pagesUpserted: counts.page,
+      ...(failed.length > 0 && { partial: failed }),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error(`[Bing Sync] Error syncing site ${siteId}:`, message);
+    return { success: false, ...empty, error: message };
+  }
+}

--- a/prisma/migrations/20260827120000_add_bing_webmaster/migration.sql
+++ b/prisma/migrations/20260827120000_add_bing_webmaster/migration.sql
@@ -1,0 +1,53 @@
+-- AlterTable
+ALTER TABLE "Site" ADD COLUMN     "bingSite" TEXT;
+
+-- CreateTable
+CREATE TABLE "BingDaily" (
+    "id" TEXT NOT NULL,
+    "siteId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "clicks" INTEGER,
+    "impressions" INTEGER,
+    "crawledPages" INTEGER,
+    "inIndex" INTEGER,
+    "inLinks" INTEGER,
+    "code2xx" INTEGER,
+    "code301" INTEGER,
+    "code302" INTEGER,
+    "code4xx" INTEGER,
+    "code5xx" INTEGER,
+    "blockedByRobots" INTEGER,
+    "crawlErrors" INTEGER,
+
+    CONSTRAINT "BingDaily_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BingSearchWeekly" (
+    "id" TEXT NOT NULL,
+    "siteId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "weekEnding" TIMESTAMP(3) NOT NULL,
+    "clicks" INTEGER NOT NULL DEFAULT 0,
+    "impressions" INTEGER NOT NULL DEFAULT 0,
+    "avgImpressionPosition" DOUBLE PRECISION,
+
+    CONSTRAINT "BingSearchWeekly_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BingDaily_siteId_date_key" ON "BingDaily"("siteId", "date");
+
+-- CreateIndex
+CREATE INDEX "BingSearchWeekly_siteId_kind_weekEnding_idx" ON "BingSearchWeekly"("siteId", "kind", "weekEnding");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BingSearchWeekly_siteId_kind_key_weekEnding_key" ON "BingSearchWeekly"("siteId", "kind", "key", "weekEnding");
+
+-- AddForeignKey
+ALTER TABLE "BingDaily" ADD CONSTRAINT "BingDaily_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BingSearchWeekly" ADD CONSTRAINT "BingSearchWeekly_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Site {
   userId      String
   domain      String   // e.g. "brandson.digital"
   gscProperty String?  // e.g. "sc-domain:brandson.digital"
+  bingSite    String?  // e.g. "https://brandson.digital/" (Bing's own URL form)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -96,6 +97,8 @@ model Site {
   alerts        Alert[]
   savedKeywords SavedKeyword[]
   rankSnapshots RankSnapshot[]
+  bingDaily     BingDaily[]
+  bingWeekly    BingSearchWeekly[]
 
   @@unique([userId, domain])
 }
@@ -137,6 +140,51 @@ model Page {
   @@unique([siteId, url, date])
   @@index([siteId, date])
   @@index([siteId, url, date])
+}
+
+// ============ BING WEBMASTER DATA ============
+
+/// Bing's daily grain: site traffic (GetRankAndTrafficStats) and crawler stats
+/// (GetCrawlStats) share one row because both are keyed by (site, day).
+/// Kept apart from Keyword/Page so no existing Google query changes meaning.
+model BingDaily {
+  id              String   @id @default(cuid())
+  siteId          String
+  date            DateTime
+  clicks          Int?
+  impressions     Int?
+  crawledPages    Int?
+  inIndex         Int?
+  inLinks         Int?
+  code2xx         Int?
+  code301         Int?
+  code302         Int?
+  code4xx         Int?
+  code5xx         Int?
+  blockedByRobots Int?
+  crawlErrors     Int?
+
+  site            Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@unique([siteId, date])
+}
+
+/// Bing's weekly grain: GetQueryStats and GetPageStats return the same contract
+/// in buckets ending on a Friday, so `kind` distinguishes them.
+model BingSearchWeekly {
+  id                    String   @id @default(cuid())
+  siteId                String
+  kind                  String   // "query" | "page"
+  key                   String   // the search query, or the page URL
+  weekEnding            DateTime
+  clicks                Int      @default(0)
+  impressions           Int      @default(0)
+  avgImpressionPosition Float?
+
+  site                  Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@unique([siteId, kind, key, weekEnding])
+  @@index([siteId, kind, weekEnding])
 }
 
 // ============ SAVED KEYWORDS ============

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,9 @@
     },
     "app/api/gsc/sync/route.ts": {
       "maxDuration": 60
+    },
+    "app/api/bing/sync/route.ts": {
+      "maxDuration": 60
     }
   }
 }


### PR DESCRIPTION
## What this adds

Bing Webmaster Tools as a second search data source, next to Google Search Console. Bring-your-own-key, optional, and additive: nothing that exists today changes shape or meaning.

- **Settings → External API Keys → Bing Webmaster Tools**: store the key (encrypted in the existing `ApiKey` table, provider `bing`), **Test Connection** calls `GetUserSites`, which is free and needs no site.
- **Settings → Bing Webmaster property**: pick which verified Bing property maps to this site. Stored in `Site.bingSite`, separately from `gscProperty`, because the two rarely agree (Bing may know `https://example.com/` where Search Console knows `https://www.example.com/`).
- **Sync** (`POST /api/bing/sync`, also wired into `vercel.json` with the same 60 s budget as the GSC sync): pulls `GetRankAndTrafficStats`, `GetCrawlStats`, `GetQueryStats` and `GetPageStats` for the property and upserts them.
- **Two new tables**, one per grain the API actually has: `BingDaily` (site traffic + crawler stats, keyed by site/day) and `BingSearchWeekly` (queries and pages, keyed by site/kind/key/week). Migration included. `Keyword`/`Page` are untouched, so every existing Google query returns exactly what it did before.
- `DEVELOPMENT.md` section with setup steps and the two facts about Bing's numbers a reader needs before trusting them.

This PR is the data layer. A follow-up puts the data on screen (a Bing vs Google view, and a source filter on the existing tables); keeping that separate keeps this one reviewable.

## Why Bing is worth a second source

It is not about Bing's share of traffic. It is about what the two APIs disclose:

1. **Queries Search Console anonymises.** GSC drops low-volume queries from the `query` dimension, which on a small or long-tail site is most of them (the overview gate in #33 is a symptom of the same thing). Bing's `GetQueryStats` reports the actual query text at very low volumes, including full-sentence questions and misspelled brand searches. That is intent data the pipeline currently never sees.
2. **The same query ranked in two indexes.** When a page ranks in the top 5 on Bing and page 5 on Google for the same term, the page is relevant and what it lacks is authority, not content. That diagnosis needs both positions side by side, and nothing else in the stack gives it for free.
3. **Crawler statistics by API.** Search Console has no Crawl Stats API. `GetCrawlStats` is daily: pages crawled, in index, 2xx/301/4xx/5xx counts, robots blocks, crawl errors.
4. **DuckDuckGo, Copilot and ChatGPT search** are served from Bing's index, so a site verified in Bing is measured there too.

One key covers every verified property on the account, which is exactly the grain of the existing BYOK `ApiKey` table.

## What the API actually does (measured, and why the code looks the way it does)

None of this is in Microsoft's docs; each item cost a measurement and is commented where it matters in the code.

- **No date range parameter, on any method.** Every call returns the full history. The sync is therefore a full refresh + upsert, and there is no backfill to write.
- **`GetQueryStats` and `GetPageStats` are weekly**, in buckets ending on a Friday; only `GetRankAndTrafficStats` and `GetCrawlStats` are daily. Treating query stats as a daily series invents Friday spikes. That single fact is why there are two tables and not one. In `GetPageStats` the URL arrives in the `Query` field.
- **`AvgClickPosition: -1` means "no clicks"**, not rank −1. It is stored as `null`; averaging it would produce negative positions.
- **Repeated keys inside one bucket** are summed before upsert, so they add up instead of last-write-wins.
- **.NET dates** (`/Date(1747983600000-0700)/`) carry Bing's own timezone offset; the offset is added back before formatting or the calendar day slides one back. The offset flips with DST.
- **In `GetCrawlStats` only `CrawledPages` is a per-day count.** `code2xx`, `inIndex`, `inLinks` etc. are running snapshots of URLs Bing knows in that state (measured: `code2xx` returned the same ~4,200 on every day of a 27-day window). Summing them over a window multiplies the truth by the day count. The column comments say so; the follow-up UI reports them as latest value + movement.
- **Four endpoints per sync run under `Promise.allSettled`**, so one flaky endpoint no longer discards the three that answered (with no date window, a retry re-downloads 16 months).
- **Changing a site's Bing property purges the old property's rows** in the same transaction, instead of blending two properties under one site.
- **`GetLinkCounts` returns empty** on every property tested and **`GetCrawlIssues` returns no rows** while the Bing UI shows errors, so neither is used. Copilot/AI citation endpoints do not exist (404). The retirement announced for 2026-08-31 is SOAP/POX only; `/api.svc/json/`, which this uses, is the surviving surface.

## Tests

`lib/bing/bing-parse.test.ts` (8 tests) covers the parsing rules above: date offset across both DST values and landing on a Friday, the −1 sentinel, in-bucket aggregation, week separation, and impression-weighted position collapse (including all-sentinel weeks). Fixtures are synthetic. `tsc`, `eslint` on the touched files, and the full vitest suite pass locally.

## Not in this PR

Screens (follow-up). Backlinks from Bing (measured empty, not built). Any change to Google data or its tables.
