### PR TITLE
fix: stop flagging alt="" as a missing alt attribute

### DIFF
--- a/lib/crawler/engine.test.ts
+++ b/lib/crawler/engine.test.ts
@@ -300,8 +300,10 @@ describe("parseHtml with quoted attribute values", () => {
     expect(page.links[0]?.isNofollow).toBe(true);
   });
 
-  it("still treats an empty alt as missing", () => {
-    expect(page.imagesMissingAlt).toBe(1);
+  it("does not treat an empty alt as missing", () => {
+    // alt="" is how a decorative image is marked up; it is not a defect.
+    expect(page.imageCount).toBe(1);
+    expect(page.imagesMissingAlt).toBe(0);
   });
 });
 
@@ -351,6 +353,15 @@ describe("parseHtml attribute lookup edge cases", () => {
 
   it("treats a whitespace-only alt as present, like the quoted patterns did", () => {
     const page = parse('<img src="/a.png" alt=" "><img src="/b.png">');
+    expect(page.imagesMissingAlt).toBe(1);
+  });
+
+  it("separates a decorative image from one with no alt at all", () => {
+    const page = parse(
+      '<img src="/logo.png" alt=""><img src="/decor.png"><img src="/hero.png" alt="Hero">'
+    );
+    expect(page.imageCount).toBe(3);
+    // Only /decor.png is a defect: alt="" marks /logo.png decorative on purpose.
     expect(page.imagesMissingAlt).toBe(1);
   });
 });

--- a/lib/crawler/engine.ts
+++ b/lib/crawler/engine.ts
@@ -321,11 +321,13 @@ export function parseHtml(
   // Images
   const imgTags = tagsNamed(html, "img");
   const imageCount = imgTags.length;
-  // An empty alt still counts as missing, exactly as before: the old pattern
-  // required `[^"']+`. A whitespace-only alt still counts as PRESENT, also as
-  // before — values are not trimmed.
+  // Only a genuinely absent alt attribute counts as missing. `alt=""` is the
+  // spec-mandated markup for a decorative image — it tells assistive tech to
+  // skip the image — so flagging it inverts the accessibility advice the issue
+  // is meant to give. A whitespace-only alt still counts as present: values are
+  // not trimmed.
   const imagesMissingAlt = imgTags.filter(
-    (tag) => !parseAttrs(tag).get("alt")
+    (tag) => !parseAttrs(tag).has("alt")
   ).length;
 
   // Body text and word count


### PR DESCRIPTION
## The behaviour

`parseHtml` counts an image as missing its alt whenever the attribute is falsy:

```ts
const imagesMissingAlt = imgTags.filter(
  (tag) => !parseAttrs(tag).get("alt")
).length;
```

That lumps `alt=""` in with a genuinely absent attribute. But `alt=""` is the spec-mandated markup for a **decorative** image — it tells assistive technology to skip it, and it is exactly what the WCAG and Google image guidelines ask for. Flagging it inverts the advice `MISSING_ALT` exists to give.

I realise the current behaviour is deliberate — the comment says it preserves what the old `[^"']+` pattern did, and a test pins it. This PR argues the preserved behaviour was the bug.

## Why it matters more than it looks

Decorative images live in shared layouts, so the warning multiplies across the whole site.

Two real sites I crawled, each with a logo in the header and one in the footer, both marked `alt=""`:

| Site | Pages | Total issues | of which `MISSING_ALT` | Health score |
|---|---:|---:|---:|---:|
| A | 30 | 39 | 30 | **2 / 100** |
| B | 30 | 31 | 30 | **10 / 100** |

Two correctly marked images produced 60 warnings across the two sites and pushed both health scores into single digits, burying the genuine findings underneath. Site B's only other issue was a real one; it was impossible to see.

## The change

The filter tests attribute **presence** instead of truthiness:

```ts
const imagesMissingAlt = imgTags.filter(
  (tag) => !parseAttrs(tag).has("alt")
).length;
```

`parseAttrs` stores `""` for a valueless attribute, so both `alt=""` and the bare `alt` form now count as present — both are valid decorative markup. A whitespace-only alt still counts as present as well: values are not trimmed, unchanged from today.

## Tests

- `still treats an empty alt as missing` asserted the old behaviour; it is updated and renamed.
- A new case pins the distinction:

```ts
const page = parse(
  '<img src="/logo.png" alt=""><img src="/decor.png"><img src="/hero.png" alt="Hero">'
);
expect(page.imageCount).toBe(3);
expect(page.imagesMissingAlt).toBe(1); // only /decor.png
```

The unquoted-attribute fixture (`<img src=/logo.png alt=Logo>` + `<img src=/decor.png>`) still expects 1 of 2 — a genuinely absent alt is still a defect.

`npx tsc --noEmit` clean · `npx eslint` on both touched files reports no errors · `npm test` 53/53 · `npm run build` succeeds.

Happy to drop this if you would rather keep flagging empty alt — but in that case the issue text should probably say "empty or missing alt", since the current wording sends people to add alt text to images that are correctly marked decorative.