### PR TITLE
fix: portfolio dashboard no longer hides sites that have pages but no keywords

### DIFF
--- a/app/(dashboard)/dashboard/page.test.ts
+++ b/app/(dashboard)/dashboard/page.test.ts
@@ -1,0 +1,81 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+// Search Console anonymises the query dimension on low-traffic properties, so
+// a sync can legitimately store pages and zero keywords. The portfolio
+// dashboard used to treat "no keywords" as "no sync yet": the onboarding
+// checklist kept demanding a first sync and the site card hid its metrics
+// behind "Waiting for first GSC sync…" — even though the Page model (the
+// source for those metrics, see lib/seo-metrics.ts) already has data.
+
+const counts = vi.hoisted(() => ({ keywords: 0, pages: 0, crawls: 0 }));
+
+vi.mock("@/lib/auth", () => ({ auth: async () => ({ user: { id: "user-1" } }) }));
+vi.mock("@/lib/db", () => ({
+  db: {
+    site: {
+      findMany: async () => [
+        {
+          id: "site-a",
+          domain: "a.example",
+          gscProperty: "https://a.example/",
+          _count: counts,
+        },
+      ],
+    },
+  },
+}));
+vi.mock("@/lib/seo-metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/seo-metrics")>();
+  return {
+    ...actual,
+    getSitePeriodMetrics: async () => ({
+      current: { clicks: 120, impressions: 4800, avgPosition: 9.2, avgCtr: 0.025, uniqueKeywords: 0 },
+      previous: { clicks: 90, impressions: 4000, avgPosition: 11.4, avgCtr: 0.0225, uniqueKeywords: 0 },
+      deltas: { clicks: 33.3, impressions: 20, avgPosition: 2.2, avgCtr: 11.1 },
+    }),
+  };
+});
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/",
+}));
+vi.mock("next-auth/react", () => ({ signIn: vi.fn() }));
+// Client components under test (the dashboard is what we render, but these
+// children pull in browser-only hooks / modals we do not want in a node test).
+vi.mock("@/components/sites/add-site-modal", () => ({ AddSiteModal: () => null }));
+vi.mock("@/components/ui/data-lag-badge", () => ({ DataLagBadge: () => null }));
+
+import DashboardPage from "./page";
+
+async function render(next: typeof counts): Promise<string> {
+  Object.assign(counts, next);
+  const tree = await DashboardPage();
+  return renderToString(tree);
+}
+
+describe("portfolio dashboard keyword-vs-page gates", () => {
+  it("treats a site with pages but no keywords as synced and shows its metrics", async () => {
+    const html = await render({ keywords: 0, pages: 27, crawls: 1 });
+    // The card must NOT hide the site behind the waiting state.
+    expect(html).not.toContain("Waiting for first GSC sync");
+    // The onboarding checklist must no longer nag for a first sync.
+    expect(html).not.toContain("Sync GSC data");
+    // Metrics derived from the Page model are shown.
+    expect(html).toContain("Clicks");
+    expect(html).toContain("Impressions");
+  });
+
+  it("still shows the waiting state before any sync at all", async () => {
+    const html = await render({ keywords: 0, pages: 0, crawls: 0 });
+    expect(html).toContain("Waiting for first GSC sync");
+    expect(html).toContain("Sync GSC data");
+  });
+
+  it("treats a site with keywords as synced", async () => {
+    const html = await render({ keywords: 5, pages: 3, crawls: 1 });
+    expect(html).not.toContain("Waiting for first GSC sync");
+    expect(html).not.toContain("Sync GSC data");
+  });
+});

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -19,15 +19,20 @@ export default async function DashboardPage() {
       id: true,
       domain: true,
       gscProperty: true,
-      _count: { select: { keywords: true, crawls: true } },
+      _count: { select: { keywords: true, pages: true, crawls: true } },
     },
     orderBy: { domain: "asc" },
   });
 
+  // Search Console anonymises the query dimension on low-traffic sites, so a
+  // synced site can have pages but no keywords. Either one means data arrived.
+  const hasData = (s: (typeof sites)[number]) =>
+    s._count.keywords > 0 || s._count.pages > 0;
+
   // Onboarding state
   const hasSites = sites.length > 0;
   const hasGscConnected = sites.some((s) => s.gscProperty);
-  const hasSyncedData = sites.some((s) => s._count.keywords > 0);
+  const hasSyncedData = sites.some(hasData);
   const hasCrawled = sites.some((s) => s._count.crawls > 0);
   const firstSiteId = sites[0]?.id;
 
@@ -59,7 +64,9 @@ export default async function DashboardPage() {
 
   const siteCards = await Promise.all(
     sites.map(async (site) => {
-      if (site._count.keywords === 0) {
+      // Metrics are computed from the Page model (see seo-metrics), so a site
+      // whose sync stored pages but no keywords still has real data to show.
+      if (!hasData(site)) {
         return {
           site,
           metrics: null as Awaited<ReturnType<typeof getSitePeriodMetrics>> | null,


### PR DESCRIPTION
## Problem

Search Console anonymises the `query` dimension on low-traffic properties, so a sync can legitimately store **Page rows and zero Keyword rows**. The portfolio dashboard (`app/(dashboard)/dashboard/page.tsx`) still gated on keywords alone in two places:

1. **`hasSyncedData` (was line 30)** — feeds the onboarding checklist's "Sync GSC data" step. A pages-only site stayed on "Sync now" forever even though data had arrived.
2. **Site-card metrics (was line 62)** — `getSitePeriodMetrics` reads exclusively from the **Page model** (see the comment in `lib/seo-metrics.ts`: Page undercounts nothing; Keyword undercounts clicks by ~95% on real data). Yet the card was skipped whenever `_count.keywords === 0`, leaving a pages-only site on **"Waiting for first GSC sync…"** while its real, page-derived metrics went unshown.

## Fix

Same shape as #33: count `pages` too, `hasData = keywords > 0 || pages > 0`.

## Reproduction (real object)

A site with `_count = { keywords: 0, pages: 27, crawls: 1 }`:

| | Before | After |
|---|---|---|
| Site card | "Waiting for first GSC sync…" | Clicks 120 · Impressions 4.8K · Avg pos 9.2 · Keywords 0 |
| Onboarding checklist | "Sync GSC data" step incomplete ("Sync now") | step complete |

## Test

`page.test.ts` renders the page server-side with a mocked `db`/`auth` (same approach as `[siteId]/page.test.ts`). Three cases: nothing synced → waiting state; **pages but no keywords → metrics shown (fails on `main`, passes here)**; keywords → metrics shown.

## Checks

`tsc --noEmit` clean · eslint clean on both touched files · full suite 60/60.

Leaves `opportunities/page.tsx`'s keyword gate untouched (see discussion — 3 of its 4 sections are keyword-derived).